### PR TITLE
feat: connect database service to frontend with full row CRUD

### DIFF
--- a/frontend/src/app/dashboard/editor/page.tsx
+++ b/frontend/src/app/dashboard/editor/page.tsx
@@ -119,7 +119,12 @@ export default function EditorPage() {
   const handleInsertRow = useCallback(
     async (values: Record<string, unknown>) => {
       await databaseApi.insertRow(selectedTable, values, schema);
-      await fetchTableData(selectedTable, schema, rowsPerPage, page * rowsPerPage);
+      await fetchTableData(
+        selectedTable,
+        schema,
+        rowsPerPage,
+        page * rowsPerPage,
+      );
       await fetchTables(schema);
     },
     [selectedTable, schema, rowsPerPage, page, fetchTableData, fetchTables],
@@ -128,7 +133,12 @@ export default function EditorPage() {
   const handleUpdateRow = useCallback(
     async (pk: Record<string, unknown>, values: Record<string, unknown>) => {
       await databaseApi.updateRow(selectedTable, pk, values, schema);
-      await fetchTableData(selectedTable, schema, rowsPerPage, page * rowsPerPage);
+      await fetchTableData(
+        selectedTable,
+        schema,
+        rowsPerPage,
+        page * rowsPerPage,
+      );
     },
     [selectedTable, schema, rowsPerPage, page, fetchTableData],
   );
@@ -137,7 +147,12 @@ export default function EditorPage() {
     async (pk: Record<string, unknown>) => {
       await databaseApi.deleteRow(selectedTable, pk, schema);
       setSelectedRow(null);
-      await fetchTableData(selectedTable, schema, rowsPerPage, page * rowsPerPage);
+      await fetchTableData(
+        selectedTable,
+        schema,
+        rowsPerPage,
+        page * rowsPerPage,
+      );
       await fetchTables(schema);
     },
     [selectedTable, schema, rowsPerPage, page, fetchTableData, fetchTables],

--- a/frontend/src/app/dashboard/editor/page.tsx
+++ b/frontend/src/app/dashboard/editor/page.tsx
@@ -6,11 +6,12 @@ import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DataBrowser } from "@/features/editor/data-browser";
 import { DefinitionTab } from "@/features/editor/definition-tab";
+import { InsertRowDialog } from "@/features/editor/insert-row-dialog";
 import { RowInspector } from "@/features/editor/row-inspector";
 import { SqlTab } from "@/features/editor/sql-tab";
 import { TableList } from "@/features/editor/table-list";
-import { tables } from "@/lib/mock-data";
-import { cn } from "@/lib/utils";
+import type { ColumnDef, TableInfo } from "@/lib/database-api";
+import { databaseApi } from "@/lib/database-api";
 import {
   Download,
   Filter,
@@ -19,7 +20,7 @@ import {
   Shield,
   Table2,
 } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 function formatRowCount(count: number): string {
   if (count >= 1000) {
@@ -29,34 +30,143 @@ function formatRowCount(count: number): string {
 }
 
 export default function EditorPage() {
-  const [selectedTable, setSelectedTable] = useState("profiles");
+  const [schema, setSchema] = useState("public");
+  const [tables, setTables] = useState<TableInfo[]>([]);
+  const [selectedTable, setSelectedTable] = useState("");
+  const [columns, setColumns] = useState<ColumnDef[]>([]);
+  const [rows, setRows] = useState<Record<string, unknown>[]>([]);
+  const [totalRowCount, setTotalRowCount] = useState(0);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(25);
   const [selectedRow, setSelectedRow] = useState<number | null>(null);
   const [filter, setFilter] = useState("");
   const [view, setView] = useState<"data" | "definition" | "sql">("data");
+  const [insertDialogOpen, setInsertDialogOpen] = useState(false);
+
+  const fetchTables = useCallback(async (s: string) => {
+    try {
+      const list = await databaseApi.listTables(s);
+      setTables(list);
+      return list;
+    } catch (e) {
+      console.error(e);
+      setTables([]);
+      return [];
+    }
+  }, []);
+
+  const fetchTableData = useCallback(
+    async (table: string, s: string, limit: number, offset: number) => {
+      if (!table) return;
+      try {
+        const [cols, rowsResp] = await Promise.all([
+          databaseApi.listColumns(table, s),
+          databaseApi.getRows(table, s, limit, offset),
+        ]);
+        setColumns(cols);
+        setRows(rowsResp.rows ?? []);
+        setTotalRowCount(rowsResp.totalCount);
+      } catch (e) {
+        console.error(e);
+        setColumns([]);
+        setRows([]);
+        setTotalRowCount(0);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    fetchTables(schema).then((list) => {
+      if (list.length > 0) {
+        setSelectedTable(list[0].name);
+      } else {
+        setSelectedTable("");
+        setColumns([]);
+        setRows([]);
+        setTotalRowCount(0);
+      }
+    });
+  }, [schema, fetchTables]);
+
+  useEffect(() => {
+    if (!selectedTable) return;
+    setPage(0);
+    fetchTableData(selectedTable, schema, rowsPerPage, 0);
+  }, [selectedTable, schema, fetchTableData, rowsPerPage]);
+
+  useEffect(() => {
+    if (!selectedTable || page === 0) return;
+    const offset = page * rowsPerPage;
+    databaseApi
+      .getRows(selectedTable, schema, rowsPerPage, offset)
+      .then((resp) => {
+        setRows(resp.rows ?? []);
+        setTotalRowCount(resp.totalCount);
+      })
+      .catch(console.error);
+  }, [page, selectedTable, schema, rowsPerPage]);
 
   const tableInfo = tables.find((t) => t.name === selectedTable);
 
+  const handleRefresh = useCallback(() => {
+    fetchTables(schema);
+    if (selectedTable) {
+      fetchTableData(selectedTable, schema, rowsPerPage, page * rowsPerPage);
+    }
+  }, [schema, selectedTable, rowsPerPage, page, fetchTables, fetchTableData]);
+
+  const handleInsertRow = useCallback(
+    async (values: Record<string, unknown>) => {
+      await databaseApi.insertRow(selectedTable, values, schema);
+      await fetchTableData(selectedTable, schema, rowsPerPage, page * rowsPerPage);
+      await fetchTables(schema);
+    },
+    [selectedTable, schema, rowsPerPage, page, fetchTableData, fetchTables],
+  );
+
+  const handleUpdateRow = useCallback(
+    async (pk: Record<string, unknown>, values: Record<string, unknown>) => {
+      await databaseApi.updateRow(selectedTable, pk, values, schema);
+      await fetchTableData(selectedTable, schema, rowsPerPage, page * rowsPerPage);
+    },
+    [selectedTable, schema, rowsPerPage, page, fetchTableData],
+  );
+
+  const handleDeleteRow = useCallback(
+    async (pk: Record<string, unknown>) => {
+      await databaseApi.deleteRow(selectedTable, pk, schema);
+      setSelectedRow(null);
+      await fetchTableData(selectedTable, schema, rowsPerPage, page * rowsPerPage);
+      await fetchTables(schema);
+    },
+    [selectedTable, schema, rowsPerPage, page, fetchTableData, fetchTables],
+  );
+
   return (
     <div className="flex h-screen overflow-hidden">
-      {/* Left panel - Table list */}
       <TableList
+        tables={tables}
         selectedTable={selectedTable}
         onSelectTable={(name) => {
           setSelectedTable(name);
           setSelectedRow(null);
           setFilter("");
         }}
+        onSchemaChange={setSchema}
       />
 
-      {/* Main area */}
       <div className="flex flex-1 flex-col overflow-hidden">
-        {/* Header */}
         <div className="flex items-center gap-3 border-b px-4 py-2.5">
           <Table2 className="size-4 text-muted-foreground" />
-          <h1 className="text-sm font-semibold">{selectedTable}</h1>
-          <Badge variant="secondary" className="text-[10px]">
-            public
-          </Badge>
+          <h1 className="text-sm font-semibold">
+            {selectedTable || "No table selected"}
+          </h1>
+          {selectedTable && (
+            <Badge variant="secondary" className="text-[10px]">
+              {schema}
+            </Badge>
+          )}
           {tableInfo?.rls && (
             <Badge className="gap-1 bg-brand-500/15 text-brand-400 border-brand-500/20 text-[10px]">
               <Shield className="size-3" />
@@ -70,7 +180,7 @@ export default function EditorPage() {
           )}
 
           <div className="ml-auto flex items-center gap-1">
-            <Button variant="ghost" size="icon-xs">
+            <Button variant="ghost" size="icon-xs" onClick={handleRefresh}>
               <RefreshCw className="size-3.5" />
             </Button>
             <Button variant="ghost" size="icon-xs">
@@ -80,14 +190,18 @@ export default function EditorPage() {
               <Download className="size-3.5" />
             </Button>
             <Separator orientation="vertical" className="mx-1 h-4" />
-            <Button size="xs" className="gap-1">
+            <Button
+              size="xs"
+              className="gap-1"
+              disabled={!selectedTable}
+              onClick={() => setInsertDialogOpen(true)}
+            >
               <Plus className="size-3" />
               Insert
             </Button>
           </div>
         </div>
 
-        {/* Tabs */}
         <Tabs
           value={view}
           onValueChange={(v) => setView(v as typeof view)}
@@ -103,6 +217,13 @@ export default function EditorPage() {
 
           <TabsContent value="data" className="flex flex-1 overflow-hidden">
             <DataBrowser
+              columns={columns}
+              rows={rows}
+              totalCount={totalRowCount}
+              page={page}
+              rowsPerPage={rowsPerPage}
+              onPageChange={setPage}
+              onRowsPerPageChange={setRowsPerPage}
               selectedRow={selectedRow}
               onSelectRow={setSelectedRow}
               filter={filter}
@@ -110,14 +231,18 @@ export default function EditorPage() {
             />
             {selectedRow !== null && (
               <RowInspector
+                columns={columns}
+                rows={rows}
                 rowIndex={selectedRow}
                 onClose={() => setSelectedRow(null)}
+                onSave={handleUpdateRow}
+                onDelete={handleDeleteRow}
               />
             )}
           </TabsContent>
 
           <TabsContent value="definition" className="overflow-y-auto p-4">
-            <DefinitionTab />
+            <DefinitionTab columns={columns} />
           </TabsContent>
 
           <TabsContent value="sql" className="overflow-y-auto p-4">
@@ -125,6 +250,13 @@ export default function EditorPage() {
           </TabsContent>
         </Tabs>
       </div>
+
+      <InsertRowDialog
+        columns={columns}
+        open={insertDialogOpen}
+        onOpenChange={setInsertDialogOpen}
+        onInsert={handleInsertRow}
+      />
     </div>
   );
 }

--- a/frontend/src/features/editor/data-browser.tsx
+++ b/frontend/src/features/editor/data-browser.tsx
@@ -171,10 +171,20 @@ export function DataBrowser({
           <span className="text-xs tabular-nums text-muted-foreground">
             {totalCount > 0 ? `${start} - ${end} of ${totalCount}` : "0 rows"}
           </span>
-          <Button variant="ghost" size="icon-xs" disabled={!hasPrev} onClick={() => onPageChange(page - 1)}>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            disabled={!hasPrev}
+            onClick={() => onPageChange(page - 1)}
+          >
             <ChevronLeft className="size-3.5" />
           </Button>
-          <Button variant="ghost" size="icon-xs" disabled={!hasNext} onClick={() => onPageChange(page + 1)}>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            disabled={!hasNext}
+            onClick={() => onPageChange(page + 1)}
+          >
             <ChevronRight className="size-3.5" />
           </Button>
         </div>

--- a/frontend/src/features/editor/data-browser.tsx
+++ b/frontend/src/features/editor/data-browser.tsx
@@ -11,7 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import { profilesColumns, profilesRows } from "@/lib/mock-data";
+import type { ColumnDef } from "@/lib/database-api";
 import { cn } from "@/lib/utils";
 import {
   ChevronLeft,
@@ -25,6 +25,13 @@ import {
 import { useMemo } from "react";
 
 interface DataBrowserProps {
+  columns: ColumnDef[];
+  rows: Record<string, unknown>[];
+  totalCount: number;
+  page: number;
+  rowsPerPage: number;
+  onPageChange: (page: number) => void;
+  onRowsPerPageChange: (perPage: number) => void;
   selectedRow: number | null;
   onSelectRow: (idx: number | null) => void;
   filter: string;
@@ -75,15 +82,22 @@ function renderCellValue(value: unknown, colName: string) {
 }
 
 export function DataBrowser({
+  columns,
+  rows: rawRows,
+  totalCount,
+  page,
+  rowsPerPage,
+  onPageChange,
+  onRowsPerPageChange,
   selectedRow,
   onSelectRow,
   filter,
   onFilterChange,
 }: DataBrowserProps) {
   const rows = useMemo(() => {
-    if (!filter) return profilesRows;
+    if (!filter) return rawRows;
     const lower = filter.toLowerCase();
-    return profilesRows.filter((row) =>
+    return rawRows.filter((row) =>
       Object.values(row).some(
         (v) =>
           v !== null &&
@@ -91,7 +105,12 @@ export function DataBrowser({
           String(v).toLowerCase().includes(lower),
       ),
     );
-  }, [filter]);
+  }, [rawRows, filter]);
+
+  const start = page * rowsPerPage + 1;
+  const end = Math.min((page + 1) * rowsPerPage, totalCount);
+  const hasNext = (page + 1) * rowsPerPage < totalCount;
+  const hasPrev = page > 0;
 
   const rowsPerPageOptions = ["25", "50", "100", "500"];
 
@@ -129,7 +148,13 @@ export function DataBrowser({
         <Separator orientation="vertical" className="mx-1 h-4" />
 
         <span className="text-xs text-muted-foreground">Rows per page</span>
-        <Select defaultValue="25">
+        <Select
+          defaultValue={String(rowsPerPage)}
+          onValueChange={(v) => {
+            onRowsPerPageChange(Number(v));
+            onPageChange(0);
+          }}
+        >
           <SelectTrigger size="sm" className="h-6 w-16 text-xs">
             <SelectValue />
           </SelectTrigger>
@@ -144,12 +169,12 @@ export function DataBrowser({
 
         <div className="ml-auto flex items-center gap-1">
           <span className="text-xs tabular-nums text-muted-foreground">
-            1 - {rows.length} of {rows.length}
+            {totalCount > 0 ? `${start} - ${end} of ${totalCount}` : "0 rows"}
           </span>
-          <Button variant="ghost" size="icon-xs" disabled>
+          <Button variant="ghost" size="icon-xs" disabled={!hasPrev} onClick={() => onPageChange(page - 1)}>
             <ChevronLeft className="size-3.5" />
           </Button>
-          <Button variant="ghost" size="icon-xs" disabled>
+          <Button variant="ghost" size="icon-xs" disabled={!hasNext} onClick={() => onPageChange(page + 1)}>
             <ChevronRight className="size-3.5" />
           </Button>
         </div>
@@ -168,7 +193,7 @@ export function DataBrowser({
                   readOnly
                 />
               </th>
-              {profilesColumns.map((col) => (
+              {columns.map((col) => (
                 <th
                   key={col.name}
                   className="whitespace-nowrap px-3 py-2 text-left font-medium text-muted-foreground"
@@ -225,7 +250,7 @@ export function DataBrowser({
                     className="size-3.5 rounded border-input accent-primary"
                   />
                 </td>
-                {profilesColumns.map((col) => (
+                {columns.map((col) => (
                   <td key={col.name} className="px-3 py-1.5">
                     {renderCellValue(row[col.name], col.name)}
                   </td>
@@ -238,15 +263,8 @@ export function DataBrowser({
 
       {/* Footer bar */}
       <div className="flex items-center gap-3 border-t bg-panel-2 px-3 py-1.5 text-[11px] text-muted-foreground">
-        <span>
-          Query ran in <span className="text-brand-400">14ms</span>
-        </span>
-        <Separator orientation="vertical" className="h-3" />
-        <span className="truncate font-mono text-[10px]">
-          SELECT * FROM public.profiles ORDER BY created_at DESC LIMIT 25;
-        </span>
         <span className="ml-auto shrink-0 tabular-nums">
-          {rows.length} rows &middot; {profilesColumns.length} cols
+          {rows.length} rows &middot; {columns.length} cols
         </span>
       </div>
     </div>

--- a/frontend/src/features/editor/definition-tab.tsx
+++ b/frontend/src/features/editor/definition-tab.tsx
@@ -8,9 +8,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { profilesColumns } from "@/lib/mock-data";
+import type { ColumnDef } from "@/lib/database-api";
 
-export function DefinitionTab() {
+interface DefinitionTabProps {
+  columns: ColumnDef[];
+}
+
+export function DefinitionTab({ columns }: DefinitionTabProps) {
   return (
     <Card>
       <CardHeader>
@@ -28,7 +32,7 @@ export function DefinitionTab() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {profilesColumns.map((col) => (
+            {columns.map((col) => (
               <TableRow key={col.name}>
                 <TableCell className="font-mono text-foreground">
                   {col.name}

--- a/frontend/src/features/editor/insert-row-dialog.tsx
+++ b/frontend/src/features/editor/insert-row-dialog.tsx
@@ -38,8 +38,10 @@ export function InsertRowDialog({
     }
   }, [open]);
 
-  const hasAutoDefault = (col: ColumnDef) =>
-    col.isPrimaryKey && col.default != null;
+  const hasAutoDefault = useCallback(
+    (col: ColumnDef) => col.isPrimaryKey && col.default != null,
+    [],
+  );
 
   const handleSubmit = useCallback(async () => {
     setSaving(true);
@@ -80,7 +82,7 @@ export function InsertRowDialog({
     } finally {
       setSaving(false);
     }
-  }, [columns, formValues, onInsert, onOpenChange]);
+  }, [columns, formValues, onInsert, onOpenChange, hasAutoDefault]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -118,11 +120,7 @@ export function InsertRowDialog({
                   id={`insert-${col.name}`}
                   disabled={auto}
                   placeholder={
-                    auto
-                      ? `(auto: ${col.default})`
-                      : col.nullable
-                        ? "NULL"
-                        : ""
+                    auto ? `(auto: ${col.default})` : col.nullable ? "NULL" : ""
                   }
                   value={auto ? "" : (formValues[col.name] ?? "")}
                   onChange={(e) =>

--- a/frontend/src/features/editor/insert-row-dialog.tsx
+++ b/frontend/src/features/editor/insert-row-dialog.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import type { ColumnDef } from "@/lib/database-api";
+import { Key, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+interface InsertRowDialogProps {
+  columns: ColumnDef[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onInsert: (values: Record<string, unknown>) => Promise<void>;
+}
+
+export function InsertRowDialog({
+  columns,
+  open,
+  onOpenChange,
+  onInsert,
+}: InsertRowDialogProps) {
+  const [formValues, setFormValues] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setFormValues({});
+      setError(null);
+    }
+  }, [open]);
+
+  const hasAutoDefault = (col: ColumnDef) =>
+    col.isPrimaryKey && col.default != null;
+
+  const handleSubmit = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const values: Record<string, unknown> = {};
+      for (const col of columns) {
+        if (hasAutoDefault(col)) continue;
+        const raw = formValues[col.name];
+        if (raw === undefined || raw === "") {
+          if (col.nullable || col.default != null) continue;
+        }
+        if (raw === "") {
+          if (col.nullable) {
+            values[col.name] = null;
+            continue;
+          }
+        }
+        if (col.type === "bool" || col.type === "boolean") {
+          values[col.name] = raw === "true";
+        } else if (
+          col.type === "int4" ||
+          col.type === "int8" ||
+          col.type === "int2" ||
+          col.type === "float4" ||
+          col.type === "float8" ||
+          col.type === "numeric"
+        ) {
+          values[col.name] = Number(raw);
+        } else {
+          values[col.name] = raw;
+        }
+      }
+      await onInsert(values);
+      onOpenChange(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Insert failed");
+    } finally {
+      setSaving(false);
+    }
+  }, [columns, formValues, onInsert, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Insert row</DialogTitle>
+          <DialogDescription>
+            Fill in the fields below. Columns with defaults can be left blank.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          {columns.map((col) => {
+            const auto = hasAutoDefault(col);
+            return (
+              <div key={col.name} className="space-y-1">
+                <label
+                  htmlFor={`insert-${col.name}`}
+                  className="flex items-center gap-1.5 text-xs"
+                >
+                  <span className="font-mono text-foreground">{col.name}</span>
+                  <span className="text-[10px] text-muted-foreground">
+                    {col.type}
+                  </span>
+                  {col.isPrimaryKey && (
+                    <Key className="size-3 text-amber-400" />
+                  )}
+                  {col.default != null && (
+                    <span className="text-[10px] text-muted-foreground">
+                      default: {col.default}
+                    </span>
+                  )}
+                </label>
+                <Input
+                  id={`insert-${col.name}`}
+                  disabled={auto}
+                  placeholder={
+                    auto
+                      ? `(auto: ${col.default})`
+                      : col.nullable
+                        ? "NULL"
+                        : ""
+                  }
+                  value={auto ? "" : (formValues[col.name] ?? "")}
+                  onChange={(e) =>
+                    setFormValues((prev) => ({
+                      ...prev,
+                      [col.name]: e.target.value,
+                    }))
+                  }
+                  className="h-7 text-xs font-mono"
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSubmit} disabled={saving}>
+            {saving && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
+            Insert
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/editor/row-inspector.tsx
+++ b/frontend/src/features/editor/row-inspector.tsx
@@ -44,10 +44,7 @@ export function RowInspector({
     setConfirmDelete(false);
   }, [row, columns]);
 
-  const hasPk = useMemo(
-    () => columns.some((c) => c.isPrimaryKey),
-    [columns],
-  );
+  const hasPk = useMemo(() => columns.some((c) => c.isPrimaryKey), [columns]);
 
   const getPk = useCallback(() => {
     const pk: Record<string, unknown> = {};

--- a/frontend/src/features/editor/row-inspector.tsx
+++ b/frontend/src/features/editor/row-inspector.tsx
@@ -3,26 +3,121 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
-import { profilesColumns, profilesRows } from "@/lib/mock-data";
-import { Key, X } from "lucide-react";
+import type { ColumnDef } from "@/lib/database-api";
+import { Key, Loader2, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface RowInspectorProps {
+  columns: ColumnDef[];
+  rows: Record<string, unknown>[];
   rowIndex: number;
   onClose: () => void;
+  onSave: (
+    pk: Record<string, unknown>,
+    values: Record<string, unknown>,
+  ) => Promise<void>;
+  onDelete: (pk: Record<string, unknown>) => Promise<void>;
 }
 
-export function RowInspector({ rowIndex, onClose }: RowInspectorProps) {
-  const row = profilesRows[rowIndex];
+export function RowInspector({
+  columns,
+  rows,
+  rowIndex,
+  onClose,
+  onSave,
+  onDelete,
+}: RowInspectorProps) {
+  const row = rows[rowIndex];
+  const [editValues, setEditValues] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  useEffect(() => {
+    if (!row) return;
+    const vals: Record<string, string> = {};
+    for (const col of columns) {
+      const v = row[col.name];
+      vals[col.name] = v === null || v === undefined ? "" : String(v);
+    }
+    setEditValues(vals);
+    setConfirmDelete(false);
+  }, [row, columns]);
+
+  const hasPk = useMemo(
+    () => columns.some((c) => c.isPrimaryKey),
+    [columns],
+  );
+
+  const getPk = useCallback(() => {
+    const pk: Record<string, unknown> = {};
+    for (const col of columns) {
+      if (col.isPrimaryKey) pk[col.name] = row[col.name];
+    }
+    return pk;
+  }, [columns, row]);
+
+  const hasChanges = useMemo(() => {
+    if (!row) return false;
+    return columns.some((col) => {
+      if (col.isPrimaryKey) return false;
+      const original =
+        row[col.name] === null || row[col.name] === undefined
+          ? ""
+          : String(row[col.name]);
+      return editValues[col.name] !== original;
+    });
+  }, [columns, row, editValues]);
+
+  const handleSave = useCallback(async () => {
+    if (!row || !hasPk) return;
+    setSaving(true);
+    try {
+      const changedValues: Record<string, unknown> = {};
+      for (const col of columns) {
+        if (col.isPrimaryKey) continue;
+        const original =
+          row[col.name] === null || row[col.name] === undefined
+            ? ""
+            : String(row[col.name]);
+        if (editValues[col.name] !== original) {
+          const raw = editValues[col.name];
+          if (raw === "" && col.nullable) {
+            changedValues[col.name] = null;
+          } else {
+            changedValues[col.name] = raw;
+          }
+        }
+      }
+      await onSave(getPk(), changedValues);
+    } finally {
+      setSaving(false);
+    }
+  }, [row, hasPk, columns, editValues, onSave, getPk]);
+
+  const handleDelete = useCallback(async () => {
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    setDeleting(true);
+    try {
+      await onDelete(getPk());
+    } finally {
+      setDeleting(false);
+      setConfirmDelete(false);
+    }
+  }, [confirmDelete, onDelete, getPk]);
+
   if (!row) return null;
 
   return (
     <div className="flex w-[340px] shrink-0 flex-col border-l bg-panel">
-      {/* Header */}
       <div className="flex items-center justify-between border-b px-4 py-3">
         <div className="min-w-0">
           <h3 className="text-sm font-medium">Edit row</h3>
           <p className="truncate font-mono text-[11px] text-muted-foreground">
-            {String(row.id)}
+            {String(row.id ?? "")}
           </p>
         </div>
         <Button variant="ghost" size="icon-xs" onClick={onClose}>
@@ -30,51 +125,64 @@ export function RowInspector({ rowIndex, onClose }: RowInspectorProps) {
         </Button>
       </div>
 
-      {/* Fields */}
       <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
-        {profilesColumns.map((col) => {
-          const value = row[col.name];
-          return (
-            <div key={col.name} className="space-y-1">
-              <label
-                htmlFor={`field-${col.name}`}
-                className="flex items-center gap-1.5 text-xs"
-              >
-                <span className="font-mono text-foreground">{col.name}</span>
-                <span className="text-[10px] text-muted-foreground">
-                  {col.type}
-                </span>
-                {col.isPrimaryKey && <Key className="size-3 text-amber-400" />}
-              </label>
-              <Input
-                id={`field-${col.name}`}
-                readOnly
-                value={
-                  value === null || value === undefined ? "" : String(value)
-                }
-                placeholder={value === null ? "NULL" : ""}
-                className="h-7 text-xs font-mono read-only:bg-muted/40"
-              />
-            </div>
-          );
-        })}
+        {columns.map((col) => (
+          <div key={col.name} className="space-y-1">
+            <label
+              htmlFor={`field-${col.name}`}
+              className="flex items-center gap-1.5 text-xs"
+            >
+              <span className="font-mono text-foreground">{col.name}</span>
+              <span className="text-[10px] text-muted-foreground">
+                {col.type}
+              </span>
+              {col.isPrimaryKey && <Key className="size-3 text-amber-400" />}
+            </label>
+            <Input
+              id={`field-${col.name}`}
+              readOnly={col.isPrimaryKey}
+              value={editValues[col.name] ?? ""}
+              placeholder={
+                row[col.name] === null || row[col.name] === undefined
+                  ? "NULL"
+                  : ""
+              }
+              onChange={(e) =>
+                setEditValues((prev) => ({
+                  ...prev,
+                  [col.name]: e.target.value,
+                }))
+              }
+              className={`h-7 text-xs font-mono ${col.isPrimaryKey ? "read-only:bg-muted/40" : ""}`}
+            />
+          </div>
+        ))}
       </div>
 
-      {/* Footer */}
       <Separator />
       <div className="flex items-center justify-between px-4 py-3">
         <Button
           variant="ghost"
           size="sm"
           className="text-destructive hover:text-destructive"
+          disabled={!hasPk || deleting}
+          onClick={handleDelete}
         >
-          Delete
+          {deleting && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
+          {confirmDelete ? "Confirm?" : "Delete"}
         </Button>
         <div className="flex items-center gap-2">
           <Button variant="outline" size="sm" onClick={onClose}>
             Cancel
           </Button>
-          <Button size="sm">Save</Button>
+          <Button
+            size="sm"
+            disabled={!hasChanges || !hasPk || saving}
+            onClick={handleSave}
+          >
+            {saving && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
+            Save
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/features/editor/sql-tab.tsx
+++ b/frontend/src/features/editor/sql-tab.tsx
@@ -61,9 +61,7 @@ export function SqlTab() {
   );
 
   const resultColumns =
-    result?.rows && result.rows.length > 0
-      ? Object.keys(result.rows[0])
-      : [];
+    result?.rows && result.rows.length > 0 ? Object.keys(result.rows[0]) : [];
 
   return (
     <div className="space-y-4">
@@ -149,8 +147,8 @@ export function SqlTab() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {result.rows.map((row, i) => (
-                    <TableRow key={i}>
+                  {result.rows.map((row) => (
+                    <TableRow key={JSON.stringify(row)}>
                       {resultColumns.map((col) => (
                         <TableCell key={col} className="font-mono text-xs">
                           {row[col] === null ? (

--- a/frontend/src/features/editor/sql-tab.tsx
+++ b/frontend/src/features/editor/sql-tab.tsx
@@ -1,4 +1,6 @@
-import { CodeBlock } from "@/components/code-block";
+"use client";
+
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -7,44 +9,167 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Play } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { type SqlResponse, databaseApi } from "@/lib/database-api";
+import { Loader2, Play } from "lucide-react";
+import { useCallback, useState } from "react";
 
 const sampleQuery = `SELECT
-  p.id,
-  p.email,
-  p.display_name,
-  p.role,
-  p.is_active,
-  p.created_at
-FROM public.profiles p
-WHERE p.is_active = true
-ORDER BY p.created_at DESC
+  table_name,
+  table_schema
+FROM information_schema.tables
+WHERE table_schema = 'public'
+ORDER BY table_name
 LIMIT 25;`;
 
 export function SqlTab() {
+  const [query, setQuery] = useState(sampleQuery);
+  const [result, setResult] = useState<SqlResponse | null>(null);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleRun = useCallback(async () => {
+    if (!query.trim()) return;
+    setRunning(true);
+    setError(null);
+    try {
+      const resp = await databaseApi.executeSQL(query);
+      setResult(resp);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Query failed");
+      setResult(null);
+    } finally {
+      setRunning(false);
+    }
+  }, [query]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        handleRun();
+      }
+    },
+    [handleRun],
+  );
+
+  const resultColumns =
+    result?.rows && result.rows.length > 0
+      ? Object.keys(result.rows[0])
+      : [];
+
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div className="space-y-1">
-            <CardTitle>SQL Editor</CardTitle>
-            <CardDescription>
-              Run arbitrary SQL against your database
-            </CardDescription>
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <CardTitle>SQL Editor</CardTitle>
+              <CardDescription>
+                Run arbitrary SQL against your database
+              </CardDescription>
+            </div>
+            <Button
+              size="sm"
+              className="gap-1.5"
+              onClick={handleRun}
+              disabled={running}
+            >
+              {running ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Play className="size-3.5" />
+              )}
+              Run
+              <kbd className="ml-1 inline-flex h-5 items-center rounded border border-border bg-muted px-1.5 text-[10px] font-mono font-normal text-muted-foreground">
+                Cmd+Enter
+              </kbd>
+            </Button>
           </div>
-          <Button size="sm" className="gap-1.5">
-            <Play className="size-3.5" />
-            Run
-            <kbd className="ml-1 inline-flex h-5 items-center rounded border border-border bg-muted px-1.5 text-[10px] font-mono font-normal text-muted-foreground">
-              Cmd+Enter
-            </kbd>
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <CodeBlock code={sampleQuery} />
-        <p className="text-xs font-mono text-brand-400">2 rows &middot; 8ms</p>
-      </CardContent>
-    </Card>
+        </CardHeader>
+        <CardContent>
+          <textarea
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            spellCheck={false}
+            className="w-full min-h-[160px] rounded-md border bg-muted/40 px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring resize-y"
+          />
+        </CardContent>
+      </Card>
+
+      {error && (
+        <Card className="border-destructive/50">
+          <CardContent className="py-3">
+            <p className="text-sm text-destructive">{error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {result && (
+        <Card>
+          <CardHeader className="py-3">
+            <div className="flex items-center gap-3 text-xs text-muted-foreground">
+              {result.rows.length > 0 && (
+                <span>
+                  <span className="text-brand-400">{result.rows.length}</span>{" "}
+                  rows
+                </span>
+              )}
+              {result.affectedRows > 0 && (
+                <Badge variant="secondary">
+                  {result.affectedRows} affected
+                </Badge>
+              )}
+              <span>
+                in{" "}
+                <span className="text-brand-400">
+                  {result.executionTimeMs.toFixed(1)}ms
+                </span>
+              </span>
+            </div>
+          </CardHeader>
+          {resultColumns.length > 0 && (
+            <CardContent className="overflow-auto p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    {resultColumns.map((col) => (
+                      <TableHead key={col} className="font-mono text-xs">
+                        {col}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {result.rows.map((row, i) => (
+                    <TableRow key={i}>
+                      {resultColumns.map((col) => (
+                        <TableCell key={col} className="font-mono text-xs">
+                          {row[col] === null ? (
+                            <span className="italic text-muted-foreground">
+                              NULL
+                            </span>
+                          ) : (
+                            String(row[col])
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          )}
+        </Card>
+      )}
+    </div>
   );
 }

--- a/frontend/src/features/editor/table-list.tsx
+++ b/frontend/src/features/editor/table-list.tsx
@@ -40,7 +40,12 @@ interface TableListProps {
   onSchemaChange: (schema: string) => void;
 }
 
-export function TableList({ tables, selectedTable, onSelectTable, onSchemaChange }: TableListProps) {
+export function TableList({
+  tables,
+  selectedTable,
+  onSelectTable,
+  onSchemaChange,
+}: TableListProps) {
   const [schema, setSchema] = useState("public");
   const [search, setSearch] = useState("");
 

--- a/frontend/src/features/editor/table-list.tsx
+++ b/frontend/src/features/editor/table-list.tsx
@@ -14,10 +14,17 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { schemas, tables } from "@/lib/mock-data";
+import type { TableInfo } from "@/lib/database-api";
 import { cn } from "@/lib/utils";
 import { Lock, Plus, Search, Table2 } from "lucide-react";
 import { useMemo, useState } from "react";
+
+const schemas = [
+  { name: "public" },
+  { name: "auth" },
+  { name: "storage" },
+  { name: "extensions" },
+];
 
 function formatRowCount(count: number): string {
   if (count >= 1000) {
@@ -27,19 +34,21 @@ function formatRowCount(count: number): string {
 }
 
 interface TableListProps {
+  tables: TableInfo[];
   selectedTable: string;
   onSelectTable: (name: string) => void;
+  onSchemaChange: (schema: string) => void;
 }
 
-export function TableList({ selectedTable, onSelectTable }: TableListProps) {
+export function TableList({ tables, selectedTable, onSelectTable, onSchemaChange }: TableListProps) {
   const [schema, setSchema] = useState("public");
   const [search, setSearch] = useState("");
 
   const filtered = useMemo(() => {
-    return tables
-      .filter((t) => t.schema === schema)
-      .filter((t) => t.name.toLowerCase().includes(search.toLowerCase()));
-  }, [schema, search]);
+    return tables.filter((t) =>
+      t.name.toLowerCase().includes(search.toLowerCase()),
+    );
+  }, [tables, search]);
 
   return (
     <div className="flex w-60 shrink-0 flex-col border-r bg-panel">
@@ -48,7 +57,10 @@ export function TableList({ selectedTable, onSelectTable }: TableListProps) {
         <Select
           value={schema}
           onValueChange={(v) => {
-            if (v) setSchema(v);
+            if (v) {
+              setSchema(v);
+              onSchemaChange(v);
+            }
           }}
         >
           <SelectTrigger className="w-full">

--- a/frontend/src/lib/database-api.ts
+++ b/frontend/src/lib/database-api.ts
@@ -1,0 +1,203 @@
+import { GATEWAY_URL } from "./constants";
+
+export type { TableInfo, ColumnDef } from "./mock-data";
+
+export interface RowsResponse {
+  rows: Record<string, unknown>[];
+  totalCount: number;
+}
+
+export interface SqlResponse {
+  rows: Record<string, unknown>[];
+  affectedRows: number;
+  executionTimeMs: number;
+}
+
+export const databaseApi = {
+  listTables: async (schema = "public"): Promise<
+    { name: string; schema: string; rls: boolean; rowCount: number }[]
+  > => {
+    const res = await fetch(
+      `${GATEWAY_URL}/database/v1/tables?schema=${encodeURIComponent(schema)}`,
+    );
+    if (!res.ok) throw new Error("Failed to fetch tables");
+    return res.json();
+  },
+
+  createTable: async (
+    schema: string,
+    name: string,
+    columns: {
+      name: string;
+      type: string;
+      default_value?: string;
+      nullable?: boolean;
+      is_primary_key?: boolean;
+      is_unique?: boolean;
+    }[],
+  ): Promise<{ name: string; schema: string; rls: boolean; rowCount: number }> => {
+    const res = await fetch(`${GATEWAY_URL}/database/v1/tables`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ schema, name, columns }),
+    });
+    if (!res.ok) throw new Error("Failed to create table");
+    return res.json();
+  },
+
+  deleteTable: async (name: string, schema = "public"): Promise<void> => {
+    const res = await fetch(
+      `${GATEWAY_URL}/database/v1/tables/${encodeURIComponent(name)}?schema=${encodeURIComponent(schema)}`,
+      { method: "DELETE" },
+    );
+    if (!res.ok) throw new Error("Failed to delete table");
+  },
+
+  listColumns: async (
+    table: string,
+    schema = "public",
+  ): Promise<
+    {
+      name: string;
+      type: string;
+      default: string | null;
+      nullable: boolean;
+      isPrimaryKey: boolean;
+      isUnique: boolean;
+    }[]
+  > => {
+    const res = await fetch(
+      `${GATEWAY_URL}/database/v1/tables/${encodeURIComponent(table)}/columns?schema=${encodeURIComponent(schema)}`,
+    );
+    if (!res.ok) throw new Error("Failed to fetch columns");
+    const data: {
+      name: string;
+      type: string;
+      default: string;
+      nullable: boolean;
+      isPrimaryKey: boolean;
+      isUnique: boolean;
+    }[] = await res.json();
+    return data.map((col) => ({
+      ...col,
+      default: col.default || null,
+    }));
+  },
+
+  addColumn: async (
+    table: string,
+    schema: string,
+    column: {
+      name: string;
+      type: string;
+      default_value?: string;
+      nullable?: boolean;
+      is_primary_key?: boolean;
+      is_unique?: boolean;
+    },
+  ): Promise<void> => {
+    const res = await fetch(
+      `${GATEWAY_URL}/database/v1/tables/${encodeURIComponent(table)}/columns?schema=${encodeURIComponent(schema)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ column }),
+      },
+    );
+    if (!res.ok) throw new Error("Failed to add column");
+  },
+
+  deleteColumn: async (
+    table: string,
+    column: string,
+    schema = "public",
+  ): Promise<void> => {
+    const res = await fetch(
+      `${GATEWAY_URL}/database/v1/tables/${encodeURIComponent(table)}/columns/${encodeURIComponent(column)}?schema=${encodeURIComponent(schema)}`,
+      { method: "DELETE" },
+    );
+    if (!res.ok) throw new Error("Failed to delete column");
+  },
+
+  getRows: async (
+    table: string,
+    schema = "public",
+    limit = 25,
+    offset = 0,
+    orderBy?: string,
+  ): Promise<RowsResponse> => {
+    const params = new URLSearchParams({
+      schema,
+      limit: String(limit),
+      offset: String(offset),
+    });
+    if (orderBy) params.set("order_by", orderBy);
+    const res = await fetch(
+      `${GATEWAY_URL}/database/v1/tables/${encodeURIComponent(table)}/rows?${params}`,
+    );
+    if (!res.ok) throw new Error("Failed to fetch rows");
+    return res.json();
+  },
+
+  insertRow: async (
+    table: string,
+    values: Record<string, unknown>,
+    schema = "public",
+  ): Promise<Record<string, unknown>> => {
+    const res = await fetch(
+      `${GATEWAY_URL}/database/v1/tables/${encodeURIComponent(table)}/rows?schema=${encodeURIComponent(schema)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      },
+    );
+    if (!res.ok) throw new Error("Failed to insert row");
+    return res.json();
+  },
+
+  updateRow: async (
+    table: string,
+    pk: Record<string, unknown>,
+    values: Record<string, unknown>,
+    schema = "public",
+  ): Promise<Record<string, unknown>> => {
+    const res = await fetch(
+      `${GATEWAY_URL}/database/v1/tables/${encodeURIComponent(table)}/rows?schema=${encodeURIComponent(schema)}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pk, values }),
+      },
+    );
+    if (!res.ok) throw new Error("Failed to update row");
+    return res.json();
+  },
+
+  deleteRow: async (
+    table: string,
+    pk: Record<string, unknown>,
+    schema = "public",
+  ): Promise<{ affectedRows: number }> => {
+    const res = await fetch(
+      `${GATEWAY_URL}/database/v1/tables/${encodeURIComponent(table)}/rows?schema=${encodeURIComponent(schema)}`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pk }),
+      },
+    );
+    if (!res.ok) throw new Error("Failed to delete row");
+    return res.json();
+  },
+
+  executeSQL: async (query: string): Promise<SqlResponse> => {
+    const res = await fetch(`${GATEWAY_URL}/database/v1/sql`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query }),
+    });
+    if (!res.ok) throw new Error("Failed to execute SQL");
+    return res.json();
+  },
+};

--- a/frontend/src/lib/database-api.ts
+++ b/frontend/src/lib/database-api.ts
@@ -14,7 +14,9 @@ export interface SqlResponse {
 }
 
 export const databaseApi = {
-  listTables: async (schema = "public"): Promise<
+  listTables: async (
+    schema = "public",
+  ): Promise<
     { name: string; schema: string; rls: boolean; rowCount: number }[]
   > => {
     const res = await fetch(
@@ -35,7 +37,12 @@ export const databaseApi = {
       is_primary_key?: boolean;
       is_unique?: boolean;
     }[],
-  ): Promise<{ name: string; schema: string; rls: boolean; rowCount: number }> => {
+  ): Promise<{
+    name: string;
+    schema: string;
+    rls: boolean;
+    rowCount: number;
+  }> => {
     const res = await fetch(`${GATEWAY_URL}/database/v1/tables`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/gen/database/database.pb.go
+++ b/gen/database/database.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        v3.21.12
-// source: proto/database/database.proto
+// source: database/database.proto
 
 package database
 
@@ -33,7 +33,7 @@ type TableInfo struct {
 
 func (x *TableInfo) Reset() {
 	*x = TableInfo{}
-	mi := &file_proto_database_database_proto_msgTypes[0]
+	mi := &file_database_database_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -45,7 +45,7 @@ func (x *TableInfo) String() string {
 func (*TableInfo) ProtoMessage() {}
 
 func (x *TableInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[0]
+	mi := &file_database_database_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58,7 +58,7 @@ func (x *TableInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TableInfo.ProtoReflect.Descriptor instead.
 func (*TableInfo) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{0}
+	return file_database_database_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *TableInfo) GetName() string {
@@ -103,7 +103,7 @@ type ColumnDef struct {
 
 func (x *ColumnDef) Reset() {
 	*x = ColumnDef{}
-	mi := &file_proto_database_database_proto_msgTypes[1]
+	mi := &file_database_database_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -115,7 +115,7 @@ func (x *ColumnDef) String() string {
 func (*ColumnDef) ProtoMessage() {}
 
 func (x *ColumnDef) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[1]
+	mi := &file_database_database_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -128,7 +128,7 @@ func (x *ColumnDef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ColumnDef.ProtoReflect.Descriptor instead.
 func (*ColumnDef) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{1}
+	return file_database_database_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *ColumnDef) GetName() string {
@@ -182,7 +182,7 @@ type ListTablesRequest struct {
 
 func (x *ListTablesRequest) Reset() {
 	*x = ListTablesRequest{}
-	mi := &file_proto_database_database_proto_msgTypes[2]
+	mi := &file_database_database_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -194,7 +194,7 @@ func (x *ListTablesRequest) String() string {
 func (*ListTablesRequest) ProtoMessage() {}
 
 func (x *ListTablesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[2]
+	mi := &file_database_database_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -207,7 +207,7 @@ func (x *ListTablesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTablesRequest.ProtoReflect.Descriptor instead.
 func (*ListTablesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{2}
+	return file_database_database_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *ListTablesRequest) GetSchema() string {
@@ -226,7 +226,7 @@ type ListTablesResponse struct {
 
 func (x *ListTablesResponse) Reset() {
 	*x = ListTablesResponse{}
-	mi := &file_proto_database_database_proto_msgTypes[3]
+	mi := &file_database_database_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -238,7 +238,7 @@ func (x *ListTablesResponse) String() string {
 func (*ListTablesResponse) ProtoMessage() {}
 
 func (x *ListTablesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[3]
+	mi := &file_database_database_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -251,7 +251,7 @@ func (x *ListTablesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTablesResponse.ProtoReflect.Descriptor instead.
 func (*ListTablesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{3}
+	return file_database_database_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ListTablesResponse) GetTables() []*TableInfo {
@@ -272,7 +272,7 @@ type CreateTableRequest struct {
 
 func (x *CreateTableRequest) Reset() {
 	*x = CreateTableRequest{}
-	mi := &file_proto_database_database_proto_msgTypes[4]
+	mi := &file_database_database_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -284,7 +284,7 @@ func (x *CreateTableRequest) String() string {
 func (*CreateTableRequest) ProtoMessage() {}
 
 func (x *CreateTableRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[4]
+	mi := &file_database_database_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -297,7 +297,7 @@ func (x *CreateTableRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTableRequest.ProtoReflect.Descriptor instead.
 func (*CreateTableRequest) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{4}
+	return file_database_database_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *CreateTableRequest) GetSchema() string {
@@ -330,7 +330,7 @@ type CreateTableResponse struct {
 
 func (x *CreateTableResponse) Reset() {
 	*x = CreateTableResponse{}
-	mi := &file_proto_database_database_proto_msgTypes[5]
+	mi := &file_database_database_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -342,7 +342,7 @@ func (x *CreateTableResponse) String() string {
 func (*CreateTableResponse) ProtoMessage() {}
 
 func (x *CreateTableResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[5]
+	mi := &file_database_database_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -355,7 +355,7 @@ func (x *CreateTableResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTableResponse.ProtoReflect.Descriptor instead.
 func (*CreateTableResponse) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{5}
+	return file_database_database_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *CreateTableResponse) GetTable() *TableInfo {
@@ -375,7 +375,7 @@ type DeleteTableRequest struct {
 
 func (x *DeleteTableRequest) Reset() {
 	*x = DeleteTableRequest{}
-	mi := &file_proto_database_database_proto_msgTypes[6]
+	mi := &file_database_database_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -387,7 +387,7 @@ func (x *DeleteTableRequest) String() string {
 func (*DeleteTableRequest) ProtoMessage() {}
 
 func (x *DeleteTableRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[6]
+	mi := &file_database_database_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -400,7 +400,7 @@ func (x *DeleteTableRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTableRequest.ProtoReflect.Descriptor instead.
 func (*DeleteTableRequest) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{6}
+	return file_database_database_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *DeleteTableRequest) GetSchema() string {
@@ -425,7 +425,7 @@ type DeleteTableResponse struct {
 
 func (x *DeleteTableResponse) Reset() {
 	*x = DeleteTableResponse{}
-	mi := &file_proto_database_database_proto_msgTypes[7]
+	mi := &file_database_database_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -437,7 +437,7 @@ func (x *DeleteTableResponse) String() string {
 func (*DeleteTableResponse) ProtoMessage() {}
 
 func (x *DeleteTableResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[7]
+	mi := &file_database_database_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -450,7 +450,7 @@ func (x *DeleteTableResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTableResponse.ProtoReflect.Descriptor instead.
 func (*DeleteTableResponse) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{7}
+	return file_database_database_proto_rawDescGZIP(), []int{7}
 }
 
 type ListColumnsRequest struct {
@@ -463,7 +463,7 @@ type ListColumnsRequest struct {
 
 func (x *ListColumnsRequest) Reset() {
 	*x = ListColumnsRequest{}
-	mi := &file_proto_database_database_proto_msgTypes[8]
+	mi := &file_database_database_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -475,7 +475,7 @@ func (x *ListColumnsRequest) String() string {
 func (*ListColumnsRequest) ProtoMessage() {}
 
 func (x *ListColumnsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[8]
+	mi := &file_database_database_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -488,7 +488,7 @@ func (x *ListColumnsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListColumnsRequest.ProtoReflect.Descriptor instead.
 func (*ListColumnsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{8}
+	return file_database_database_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListColumnsRequest) GetSchema() string {
@@ -514,7 +514,7 @@ type ListColumnsResponse struct {
 
 func (x *ListColumnsResponse) Reset() {
 	*x = ListColumnsResponse{}
-	mi := &file_proto_database_database_proto_msgTypes[9]
+	mi := &file_database_database_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -526,7 +526,7 @@ func (x *ListColumnsResponse) String() string {
 func (*ListColumnsResponse) ProtoMessage() {}
 
 func (x *ListColumnsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[9]
+	mi := &file_database_database_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -539,7 +539,7 @@ func (x *ListColumnsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListColumnsResponse.ProtoReflect.Descriptor instead.
 func (*ListColumnsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{9}
+	return file_database_database_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ListColumnsResponse) GetColumns() []*ColumnDef {
@@ -560,7 +560,7 @@ type AddColumnRequest struct {
 
 func (x *AddColumnRequest) Reset() {
 	*x = AddColumnRequest{}
-	mi := &file_proto_database_database_proto_msgTypes[10]
+	mi := &file_database_database_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -572,7 +572,7 @@ func (x *AddColumnRequest) String() string {
 func (*AddColumnRequest) ProtoMessage() {}
 
 func (x *AddColumnRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[10]
+	mi := &file_database_database_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -585,7 +585,7 @@ func (x *AddColumnRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddColumnRequest.ProtoReflect.Descriptor instead.
 func (*AddColumnRequest) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{10}
+	return file_database_database_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *AddColumnRequest) GetSchema() string {
@@ -618,7 +618,7 @@ type AddColumnResponse struct {
 
 func (x *AddColumnResponse) Reset() {
 	*x = AddColumnResponse{}
-	mi := &file_proto_database_database_proto_msgTypes[11]
+	mi := &file_database_database_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -630,7 +630,7 @@ func (x *AddColumnResponse) String() string {
 func (*AddColumnResponse) ProtoMessage() {}
 
 func (x *AddColumnResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[11]
+	mi := &file_database_database_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -643,7 +643,7 @@ func (x *AddColumnResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddColumnResponse.ProtoReflect.Descriptor instead.
 func (*AddColumnResponse) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{11}
+	return file_database_database_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *AddColumnResponse) GetColumn() *ColumnDef {
@@ -669,7 +669,7 @@ type UpdateColumnRequest struct {
 
 func (x *UpdateColumnRequest) Reset() {
 	*x = UpdateColumnRequest{}
-	mi := &file_proto_database_database_proto_msgTypes[12]
+	mi := &file_database_database_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -681,7 +681,7 @@ func (x *UpdateColumnRequest) String() string {
 func (*UpdateColumnRequest) ProtoMessage() {}
 
 func (x *UpdateColumnRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[12]
+	mi := &file_database_database_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -694,7 +694,7 @@ func (x *UpdateColumnRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateColumnRequest.ProtoReflect.Descriptor instead.
 func (*UpdateColumnRequest) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{12}
+	return file_database_database_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *UpdateColumnRequest) GetSchema() string {
@@ -762,7 +762,7 @@ type UpdateColumnResponse struct {
 
 func (x *UpdateColumnResponse) Reset() {
 	*x = UpdateColumnResponse{}
-	mi := &file_proto_database_database_proto_msgTypes[13]
+	mi := &file_database_database_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -774,7 +774,7 @@ func (x *UpdateColumnResponse) String() string {
 func (*UpdateColumnResponse) ProtoMessage() {}
 
 func (x *UpdateColumnResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[13]
+	mi := &file_database_database_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -787,7 +787,7 @@ func (x *UpdateColumnResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateColumnResponse.ProtoReflect.Descriptor instead.
 func (*UpdateColumnResponse) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{13}
+	return file_database_database_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *UpdateColumnResponse) GetColumn() *ColumnDef {
@@ -808,7 +808,7 @@ type DeleteColumnRequest struct {
 
 func (x *DeleteColumnRequest) Reset() {
 	*x = DeleteColumnRequest{}
-	mi := &file_proto_database_database_proto_msgTypes[14]
+	mi := &file_database_database_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -820,7 +820,7 @@ func (x *DeleteColumnRequest) String() string {
 func (*DeleteColumnRequest) ProtoMessage() {}
 
 func (x *DeleteColumnRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[14]
+	mi := &file_database_database_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -833,7 +833,7 @@ func (x *DeleteColumnRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteColumnRequest.ProtoReflect.Descriptor instead.
 func (*DeleteColumnRequest) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{14}
+	return file_database_database_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DeleteColumnRequest) GetSchema() string {
@@ -865,7 +865,7 @@ type DeleteColumnResponse struct {
 
 func (x *DeleteColumnResponse) Reset() {
 	*x = DeleteColumnResponse{}
-	mi := &file_proto_database_database_proto_msgTypes[15]
+	mi := &file_database_database_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -877,7 +877,7 @@ func (x *DeleteColumnResponse) String() string {
 func (*DeleteColumnResponse) ProtoMessage() {}
 
 func (x *DeleteColumnResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[15]
+	mi := &file_database_database_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -890,7 +890,7 @@ func (x *DeleteColumnResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteColumnResponse.ProtoReflect.Descriptor instead.
 func (*DeleteColumnResponse) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{15}
+	return file_database_database_proto_rawDescGZIP(), []int{15}
 }
 
 type GetRowsRequest struct {
@@ -906,7 +906,7 @@ type GetRowsRequest struct {
 
 func (x *GetRowsRequest) Reset() {
 	*x = GetRowsRequest{}
-	mi := &file_proto_database_database_proto_msgTypes[16]
+	mi := &file_database_database_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -918,7 +918,7 @@ func (x *GetRowsRequest) String() string {
 func (*GetRowsRequest) ProtoMessage() {}
 
 func (x *GetRowsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[16]
+	mi := &file_database_database_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -931,7 +931,7 @@ func (x *GetRowsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRowsRequest.ProtoReflect.Descriptor instead.
 func (*GetRowsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{16}
+	return file_database_database_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetRowsRequest) GetSchema() string {
@@ -979,7 +979,7 @@ type GetRowsResponse struct {
 
 func (x *GetRowsResponse) Reset() {
 	*x = GetRowsResponse{}
-	mi := &file_proto_database_database_proto_msgTypes[17]
+	mi := &file_database_database_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -991,7 +991,7 @@ func (x *GetRowsResponse) String() string {
 func (*GetRowsResponse) ProtoMessage() {}
 
 func (x *GetRowsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[17]
+	mi := &file_database_database_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1004,7 +1004,7 @@ func (x *GetRowsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRowsResponse.ProtoReflect.Descriptor instead.
 func (*GetRowsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{17}
+	return file_database_database_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetRowsResponse) GetRows() [][]byte {
@@ -1021,6 +1021,326 @@ func (x *GetRowsResponse) GetTotalCount() int64 {
 	return 0
 }
 
+type InsertRowRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Schema        string                 `protobuf:"bytes,1,opt,name=schema,proto3" json:"schema,omitempty"`
+	Table         string                 `protobuf:"bytes,2,opt,name=table,proto3" json:"table,omitempty"`
+	Values        []byte                 `protobuf:"bytes,3,opt,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InsertRowRequest) Reset() {
+	*x = InsertRowRequest{}
+	mi := &file_database_database_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InsertRowRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InsertRowRequest) ProtoMessage() {}
+
+func (x *InsertRowRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_database_database_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InsertRowRequest.ProtoReflect.Descriptor instead.
+func (*InsertRowRequest) Descriptor() ([]byte, []int) {
+	return file_database_database_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *InsertRowRequest) GetSchema() string {
+	if x != nil {
+		return x.Schema
+	}
+	return ""
+}
+
+func (x *InsertRowRequest) GetTable() string {
+	if x != nil {
+		return x.Table
+	}
+	return ""
+}
+
+func (x *InsertRowRequest) GetValues() []byte {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type InsertRowResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Row           []byte                 `protobuf:"bytes,1,opt,name=row,proto3" json:"row,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InsertRowResponse) Reset() {
+	*x = InsertRowResponse{}
+	mi := &file_database_database_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InsertRowResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InsertRowResponse) ProtoMessage() {}
+
+func (x *InsertRowResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_database_database_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InsertRowResponse.ProtoReflect.Descriptor instead.
+func (*InsertRowResponse) Descriptor() ([]byte, []int) {
+	return file_database_database_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *InsertRowResponse) GetRow() []byte {
+	if x != nil {
+		return x.Row
+	}
+	return nil
+}
+
+type UpdateRowRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Schema        string                 `protobuf:"bytes,1,opt,name=schema,proto3" json:"schema,omitempty"`
+	Table         string                 `protobuf:"bytes,2,opt,name=table,proto3" json:"table,omitempty"`
+	Pk            []byte                 `protobuf:"bytes,3,opt,name=pk,proto3" json:"pk,omitempty"`
+	Values        []byte                 `protobuf:"bytes,4,opt,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateRowRequest) Reset() {
+	*x = UpdateRowRequest{}
+	mi := &file_database_database_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateRowRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateRowRequest) ProtoMessage() {}
+
+func (x *UpdateRowRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_database_database_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateRowRequest.ProtoReflect.Descriptor instead.
+func (*UpdateRowRequest) Descriptor() ([]byte, []int) {
+	return file_database_database_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *UpdateRowRequest) GetSchema() string {
+	if x != nil {
+		return x.Schema
+	}
+	return ""
+}
+
+func (x *UpdateRowRequest) GetTable() string {
+	if x != nil {
+		return x.Table
+	}
+	return ""
+}
+
+func (x *UpdateRowRequest) GetPk() []byte {
+	if x != nil {
+		return x.Pk
+	}
+	return nil
+}
+
+func (x *UpdateRowRequest) GetValues() []byte {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type UpdateRowResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Row           []byte                 `protobuf:"bytes,1,opt,name=row,proto3" json:"row,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UpdateRowResponse) Reset() {
+	*x = UpdateRowResponse{}
+	mi := &file_database_database_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UpdateRowResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateRowResponse) ProtoMessage() {}
+
+func (x *UpdateRowResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_database_database_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateRowResponse.ProtoReflect.Descriptor instead.
+func (*UpdateRowResponse) Descriptor() ([]byte, []int) {
+	return file_database_database_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *UpdateRowResponse) GetRow() []byte {
+	if x != nil {
+		return x.Row
+	}
+	return nil
+}
+
+type DeleteRowRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Schema        string                 `protobuf:"bytes,1,opt,name=schema,proto3" json:"schema,omitempty"`
+	Table         string                 `protobuf:"bytes,2,opt,name=table,proto3" json:"table,omitempty"`
+	Pk            []byte                 `protobuf:"bytes,3,opt,name=pk,proto3" json:"pk,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteRowRequest) Reset() {
+	*x = DeleteRowRequest{}
+	mi := &file_database_database_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteRowRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteRowRequest) ProtoMessage() {}
+
+func (x *DeleteRowRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_database_database_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteRowRequest.ProtoReflect.Descriptor instead.
+func (*DeleteRowRequest) Descriptor() ([]byte, []int) {
+	return file_database_database_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *DeleteRowRequest) GetSchema() string {
+	if x != nil {
+		return x.Schema
+	}
+	return ""
+}
+
+func (x *DeleteRowRequest) GetTable() string {
+	if x != nil {
+		return x.Table
+	}
+	return ""
+}
+
+func (x *DeleteRowRequest) GetPk() []byte {
+	if x != nil {
+		return x.Pk
+	}
+	return nil
+}
+
+type DeleteRowResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AffectedRows  int64                  `protobuf:"varint,1,opt,name=affected_rows,json=affectedRows,proto3" json:"affected_rows,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteRowResponse) Reset() {
+	*x = DeleteRowResponse{}
+	mi := &file_database_database_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteRowResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteRowResponse) ProtoMessage() {}
+
+func (x *DeleteRowResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_database_database_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteRowResponse.ProtoReflect.Descriptor instead.
+func (*DeleteRowResponse) Descriptor() ([]byte, []int) {
+	return file_database_database_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *DeleteRowResponse) GetAffectedRows() int64 {
+	if x != nil {
+		return x.AffectedRows
+	}
+	return 0
+}
+
 type ExecuteSQLRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Query         string                 `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
@@ -1030,7 +1350,7 @@ type ExecuteSQLRequest struct {
 
 func (x *ExecuteSQLRequest) Reset() {
 	*x = ExecuteSQLRequest{}
-	mi := &file_proto_database_database_proto_msgTypes[18]
+	mi := &file_database_database_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1042,7 +1362,7 @@ func (x *ExecuteSQLRequest) String() string {
 func (*ExecuteSQLRequest) ProtoMessage() {}
 
 func (x *ExecuteSQLRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[18]
+	mi := &file_database_database_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1055,7 +1375,7 @@ func (x *ExecuteSQLRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteSQLRequest.ProtoReflect.Descriptor instead.
 func (*ExecuteSQLRequest) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{18}
+	return file_database_database_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ExecuteSQLRequest) GetQuery() string {
@@ -1076,7 +1396,7 @@ type ExecuteSQLResponse struct {
 
 func (x *ExecuteSQLResponse) Reset() {
 	*x = ExecuteSQLResponse{}
-	mi := &file_proto_database_database_proto_msgTypes[19]
+	mi := &file_database_database_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1088,7 +1408,7 @@ func (x *ExecuteSQLResponse) String() string {
 func (*ExecuteSQLResponse) ProtoMessage() {}
 
 func (x *ExecuteSQLResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_database_database_proto_msgTypes[19]
+	mi := &file_database_database_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1101,7 +1421,7 @@ func (x *ExecuteSQLResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteSQLResponse.ProtoReflect.Descriptor instead.
 func (*ExecuteSQLResponse) Descriptor() ([]byte, []int) {
-	return file_proto_database_database_proto_rawDescGZIP(), []int{19}
+	return file_database_database_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ExecuteSQLResponse) GetRows() [][]byte {
@@ -1125,11 +1445,11 @@ func (x *ExecuteSQLResponse) GetExecutionTimeMs() float64 {
 	return 0
 }
 
-var File_proto_database_database_proto protoreflect.FileDescriptor
+var File_database_database_proto protoreflect.FileDescriptor
 
-const file_proto_database_database_proto_rawDesc = "" +
+const file_database_database_proto_rawDesc = "" +
 	"\n" +
-	"\x1dproto/database/database.proto\x12\bdatabase\"f\n" +
+	"\x17database/database.proto\x12\bdatabase\"f\n" +
 	"\tTableInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06schema\x18\x02 \x01(\tR\x06schema\x12\x10\n" +
@@ -1195,13 +1515,32 @@ const file_proto_database_database_proto_rawDesc = "" +
 	"\x0fGetRowsResponse\x12\x12\n" +
 	"\x04rows\x18\x01 \x03(\fR\x04rows\x12\x1f\n" +
 	"\vtotal_count\x18\x02 \x01(\x03R\n" +
-	"totalCount\")\n" +
+	"totalCount\"X\n" +
+	"\x10InsertRowRequest\x12\x16\n" +
+	"\x06schema\x18\x01 \x01(\tR\x06schema\x12\x14\n" +
+	"\x05table\x18\x02 \x01(\tR\x05table\x12\x16\n" +
+	"\x06values\x18\x03 \x01(\fR\x06values\"%\n" +
+	"\x11InsertRowResponse\x12\x10\n" +
+	"\x03row\x18\x01 \x01(\fR\x03row\"h\n" +
+	"\x10UpdateRowRequest\x12\x16\n" +
+	"\x06schema\x18\x01 \x01(\tR\x06schema\x12\x14\n" +
+	"\x05table\x18\x02 \x01(\tR\x05table\x12\x0e\n" +
+	"\x02pk\x18\x03 \x01(\fR\x02pk\x12\x16\n" +
+	"\x06values\x18\x04 \x01(\fR\x06values\"%\n" +
+	"\x11UpdateRowResponse\x12\x10\n" +
+	"\x03row\x18\x01 \x01(\fR\x03row\"P\n" +
+	"\x10DeleteRowRequest\x12\x16\n" +
+	"\x06schema\x18\x01 \x01(\tR\x06schema\x12\x14\n" +
+	"\x05table\x18\x02 \x01(\tR\x05table\x12\x0e\n" +
+	"\x02pk\x18\x03 \x01(\fR\x02pk\"8\n" +
+	"\x11DeleteRowResponse\x12#\n" +
+	"\raffected_rows\x18\x01 \x01(\x03R\faffectedRows\")\n" +
 	"\x11ExecuteSQLRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\"y\n" +
 	"\x12ExecuteSQLResponse\x12\x12\n" +
 	"\x04rows\x18\x01 \x03(\fR\x04rows\x12#\n" +
 	"\raffected_rows\x18\x02 \x01(\x03R\faffectedRows\x12*\n" +
-	"\x11execution_time_ms\x18\x03 \x01(\x01R\x0fexecutionTimeMs2\xab\x05\n" +
+	"\x11execution_time_ms\x18\x03 \x01(\x01R\x0fexecutionTimeMs2\xfd\x06\n" +
 	"\x0fDatabaseService\x12G\n" +
 	"\n" +
 	"ListTables\x12\x1b.database.ListTablesRequest\x1a\x1c.database.ListTablesResponse\x12J\n" +
@@ -1211,24 +1550,27 @@ const file_proto_database_database_proto_rawDesc = "" +
 	"\tAddColumn\x12\x1a.database.AddColumnRequest\x1a\x1b.database.AddColumnResponse\x12M\n" +
 	"\fUpdateColumn\x12\x1d.database.UpdateColumnRequest\x1a\x1e.database.UpdateColumnResponse\x12M\n" +
 	"\fDeleteColumn\x12\x1d.database.DeleteColumnRequest\x1a\x1e.database.DeleteColumnResponse\x12>\n" +
-	"\aGetRows\x12\x18.database.GetRowsRequest\x1a\x19.database.GetRowsResponse\x12G\n" +
+	"\aGetRows\x12\x18.database.GetRowsRequest\x1a\x19.database.GetRowsResponse\x12D\n" +
+	"\tInsertRow\x12\x1a.database.InsertRowRequest\x1a\x1b.database.InsertRowResponse\x12D\n" +
+	"\tUpdateRow\x12\x1a.database.UpdateRowRequest\x1a\x1b.database.UpdateRowResponse\x12D\n" +
+	"\tDeleteRow\x12\x1a.database.DeleteRowRequest\x1a\x1b.database.DeleteRowResponse\x12G\n" +
 	"\n" +
-	"ExecuteSQL\x12\x1b.database.ExecuteSQLRequest\x1a\x1c.database.ExecuteSQLResponseB\x10Z\x0eproto/databaseb\x06proto3"
+	"ExecuteSQL\x12\x1b.database.ExecuteSQLRequest\x1a\x1c.database.ExecuteSQLResponseB.Z,github.com/KinuGra/giraffe-2604/gen/databaseb\x06proto3"
 
 var (
-	file_proto_database_database_proto_rawDescOnce sync.Once
-	file_proto_database_database_proto_rawDescData []byte
+	file_database_database_proto_rawDescOnce sync.Once
+	file_database_database_proto_rawDescData []byte
 )
 
-func file_proto_database_database_proto_rawDescGZIP() []byte {
-	file_proto_database_database_proto_rawDescOnce.Do(func() {
-		file_proto_database_database_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_proto_database_database_proto_rawDesc), len(file_proto_database_database_proto_rawDesc)))
+func file_database_database_proto_rawDescGZIP() []byte {
+	file_database_database_proto_rawDescOnce.Do(func() {
+		file_database_database_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_database_database_proto_rawDesc), len(file_database_database_proto_rawDesc)))
 	})
-	return file_proto_database_database_proto_rawDescData
+	return file_database_database_proto_rawDescData
 }
 
-var file_proto_database_database_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
-var file_proto_database_database_proto_goTypes = []any{
+var file_database_database_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_database_database_proto_goTypes = []any{
 	(*TableInfo)(nil),            // 0: database.TableInfo
 	(*ColumnDef)(nil),            // 1: database.ColumnDef
 	(*ListTablesRequest)(nil),    // 2: database.ListTablesRequest
@@ -1247,10 +1589,16 @@ var file_proto_database_database_proto_goTypes = []any{
 	(*DeleteColumnResponse)(nil), // 15: database.DeleteColumnResponse
 	(*GetRowsRequest)(nil),       // 16: database.GetRowsRequest
 	(*GetRowsResponse)(nil),      // 17: database.GetRowsResponse
-	(*ExecuteSQLRequest)(nil),    // 18: database.ExecuteSQLRequest
-	(*ExecuteSQLResponse)(nil),   // 19: database.ExecuteSQLResponse
+	(*InsertRowRequest)(nil),     // 18: database.InsertRowRequest
+	(*InsertRowResponse)(nil),    // 19: database.InsertRowResponse
+	(*UpdateRowRequest)(nil),     // 20: database.UpdateRowRequest
+	(*UpdateRowResponse)(nil),    // 21: database.UpdateRowResponse
+	(*DeleteRowRequest)(nil),     // 22: database.DeleteRowRequest
+	(*DeleteRowResponse)(nil),    // 23: database.DeleteRowResponse
+	(*ExecuteSQLRequest)(nil),    // 24: database.ExecuteSQLRequest
+	(*ExecuteSQLResponse)(nil),   // 25: database.ExecuteSQLResponse
 }
-var file_proto_database_database_proto_depIdxs = []int32{
+var file_database_database_proto_depIdxs = []int32{
 	0,  // 0: database.ListTablesResponse.tables:type_name -> database.TableInfo
 	1,  // 1: database.CreateTableRequest.columns:type_name -> database.ColumnDef
 	0,  // 2: database.CreateTableResponse.table:type_name -> database.TableInfo
@@ -1266,43 +1614,49 @@ var file_proto_database_database_proto_depIdxs = []int32{
 	12, // 12: database.DatabaseService.UpdateColumn:input_type -> database.UpdateColumnRequest
 	14, // 13: database.DatabaseService.DeleteColumn:input_type -> database.DeleteColumnRequest
 	16, // 14: database.DatabaseService.GetRows:input_type -> database.GetRowsRequest
-	18, // 15: database.DatabaseService.ExecuteSQL:input_type -> database.ExecuteSQLRequest
-	3,  // 16: database.DatabaseService.ListTables:output_type -> database.ListTablesResponse
-	5,  // 17: database.DatabaseService.CreateTable:output_type -> database.CreateTableResponse
-	7,  // 18: database.DatabaseService.DeleteTable:output_type -> database.DeleteTableResponse
-	9,  // 19: database.DatabaseService.ListColumns:output_type -> database.ListColumnsResponse
-	11, // 20: database.DatabaseService.AddColumn:output_type -> database.AddColumnResponse
-	13, // 21: database.DatabaseService.UpdateColumn:output_type -> database.UpdateColumnResponse
-	15, // 22: database.DatabaseService.DeleteColumn:output_type -> database.DeleteColumnResponse
-	17, // 23: database.DatabaseService.GetRows:output_type -> database.GetRowsResponse
-	19, // 24: database.DatabaseService.ExecuteSQL:output_type -> database.ExecuteSQLResponse
-	16, // [16:25] is the sub-list for method output_type
-	7,  // [7:16] is the sub-list for method input_type
+	18, // 15: database.DatabaseService.InsertRow:input_type -> database.InsertRowRequest
+	20, // 16: database.DatabaseService.UpdateRow:input_type -> database.UpdateRowRequest
+	22, // 17: database.DatabaseService.DeleteRow:input_type -> database.DeleteRowRequest
+	24, // 18: database.DatabaseService.ExecuteSQL:input_type -> database.ExecuteSQLRequest
+	3,  // 19: database.DatabaseService.ListTables:output_type -> database.ListTablesResponse
+	5,  // 20: database.DatabaseService.CreateTable:output_type -> database.CreateTableResponse
+	7,  // 21: database.DatabaseService.DeleteTable:output_type -> database.DeleteTableResponse
+	9,  // 22: database.DatabaseService.ListColumns:output_type -> database.ListColumnsResponse
+	11, // 23: database.DatabaseService.AddColumn:output_type -> database.AddColumnResponse
+	13, // 24: database.DatabaseService.UpdateColumn:output_type -> database.UpdateColumnResponse
+	15, // 25: database.DatabaseService.DeleteColumn:output_type -> database.DeleteColumnResponse
+	17, // 26: database.DatabaseService.GetRows:output_type -> database.GetRowsResponse
+	19, // 27: database.DatabaseService.InsertRow:output_type -> database.InsertRowResponse
+	21, // 28: database.DatabaseService.UpdateRow:output_type -> database.UpdateRowResponse
+	23, // 29: database.DatabaseService.DeleteRow:output_type -> database.DeleteRowResponse
+	25, // 30: database.DatabaseService.ExecuteSQL:output_type -> database.ExecuteSQLResponse
+	19, // [19:31] is the sub-list for method output_type
+	7,  // [7:19] is the sub-list for method input_type
 	7,  // [7:7] is the sub-list for extension type_name
 	7,  // [7:7] is the sub-list for extension extendee
 	0,  // [0:7] is the sub-list for field type_name
 }
 
-func init() { file_proto_database_database_proto_init() }
-func file_proto_database_database_proto_init() {
-	if File_proto_database_database_proto != nil {
+func init() { file_database_database_proto_init() }
+func file_database_database_proto_init() {
+	if File_database_database_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_database_database_proto_rawDesc), len(file_proto_database_database_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_database_database_proto_rawDesc), len(file_database_database_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   20,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_proto_database_database_proto_goTypes,
-		DependencyIndexes: file_proto_database_database_proto_depIdxs,
-		MessageInfos:      file_proto_database_database_proto_msgTypes,
+		GoTypes:           file_database_database_proto_goTypes,
+		DependencyIndexes: file_database_database_proto_depIdxs,
+		MessageInfos:      file_database_database_proto_msgTypes,
 	}.Build()
-	File_proto_database_database_proto = out.File
-	file_proto_database_database_proto_goTypes = nil
-	file_proto_database_database_proto_depIdxs = nil
+	File_database_database_proto = out.File
+	file_database_database_proto_goTypes = nil
+	file_database_database_proto_depIdxs = nil
 }

--- a/gen/database/database_grpc.pb.go
+++ b/gen/database/database_grpc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // - protoc-gen-go-grpc v1.6.1
 // - protoc             v3.21.12
-// source: proto/database/database.proto
+// source: database/database.proto
 
 package database
 
@@ -27,6 +27,9 @@ const (
 	DatabaseService_UpdateColumn_FullMethodName = "/database.DatabaseService/UpdateColumn"
 	DatabaseService_DeleteColumn_FullMethodName = "/database.DatabaseService/DeleteColumn"
 	DatabaseService_GetRows_FullMethodName      = "/database.DatabaseService/GetRows"
+	DatabaseService_InsertRow_FullMethodName    = "/database.DatabaseService/InsertRow"
+	DatabaseService_UpdateRow_FullMethodName    = "/database.DatabaseService/UpdateRow"
+	DatabaseService_DeleteRow_FullMethodName    = "/database.DatabaseService/DeleteRow"
 	DatabaseService_ExecuteSQL_FullMethodName   = "/database.DatabaseService/ExecuteSQL"
 )
 
@@ -42,6 +45,9 @@ type DatabaseServiceClient interface {
 	UpdateColumn(ctx context.Context, in *UpdateColumnRequest, opts ...grpc.CallOption) (*UpdateColumnResponse, error)
 	DeleteColumn(ctx context.Context, in *DeleteColumnRequest, opts ...grpc.CallOption) (*DeleteColumnResponse, error)
 	GetRows(ctx context.Context, in *GetRowsRequest, opts ...grpc.CallOption) (*GetRowsResponse, error)
+	InsertRow(ctx context.Context, in *InsertRowRequest, opts ...grpc.CallOption) (*InsertRowResponse, error)
+	UpdateRow(ctx context.Context, in *UpdateRowRequest, opts ...grpc.CallOption) (*UpdateRowResponse, error)
+	DeleteRow(ctx context.Context, in *DeleteRowRequest, opts ...grpc.CallOption) (*DeleteRowResponse, error)
 	ExecuteSQL(ctx context.Context, in *ExecuteSQLRequest, opts ...grpc.CallOption) (*ExecuteSQLResponse, error)
 }
 
@@ -133,6 +139,36 @@ func (c *databaseServiceClient) GetRows(ctx context.Context, in *GetRowsRequest,
 	return out, nil
 }
 
+func (c *databaseServiceClient) InsertRow(ctx context.Context, in *InsertRowRequest, opts ...grpc.CallOption) (*InsertRowResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(InsertRowResponse)
+	err := c.cc.Invoke(ctx, DatabaseService_InsertRow_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *databaseServiceClient) UpdateRow(ctx context.Context, in *UpdateRowRequest, opts ...grpc.CallOption) (*UpdateRowResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(UpdateRowResponse)
+	err := c.cc.Invoke(ctx, DatabaseService_UpdateRow_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *databaseServiceClient) DeleteRow(ctx context.Context, in *DeleteRowRequest, opts ...grpc.CallOption) (*DeleteRowResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteRowResponse)
+	err := c.cc.Invoke(ctx, DatabaseService_DeleteRow_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *databaseServiceClient) ExecuteSQL(ctx context.Context, in *ExecuteSQLRequest, opts ...grpc.CallOption) (*ExecuteSQLResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ExecuteSQLResponse)
@@ -155,6 +191,9 @@ type DatabaseServiceServer interface {
 	UpdateColumn(context.Context, *UpdateColumnRequest) (*UpdateColumnResponse, error)
 	DeleteColumn(context.Context, *DeleteColumnRequest) (*DeleteColumnResponse, error)
 	GetRows(context.Context, *GetRowsRequest) (*GetRowsResponse, error)
+	InsertRow(context.Context, *InsertRowRequest) (*InsertRowResponse, error)
+	UpdateRow(context.Context, *UpdateRowRequest) (*UpdateRowResponse, error)
+	DeleteRow(context.Context, *DeleteRowRequest) (*DeleteRowResponse, error)
 	ExecuteSQL(context.Context, *ExecuteSQLRequest) (*ExecuteSQLResponse, error)
 	mustEmbedUnimplementedDatabaseServiceServer()
 }
@@ -189,6 +228,15 @@ func (UnimplementedDatabaseServiceServer) DeleteColumn(context.Context, *DeleteC
 }
 func (UnimplementedDatabaseServiceServer) GetRows(context.Context, *GetRowsRequest) (*GetRowsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetRows not implemented")
+}
+func (UnimplementedDatabaseServiceServer) InsertRow(context.Context, *InsertRowRequest) (*InsertRowResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method InsertRow not implemented")
+}
+func (UnimplementedDatabaseServiceServer) UpdateRow(context.Context, *UpdateRowRequest) (*UpdateRowResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method UpdateRow not implemented")
+}
+func (UnimplementedDatabaseServiceServer) DeleteRow(context.Context, *DeleteRowRequest) (*DeleteRowResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteRow not implemented")
 }
 func (UnimplementedDatabaseServiceServer) ExecuteSQL(context.Context, *ExecuteSQLRequest) (*ExecuteSQLResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ExecuteSQL not implemented")
@@ -358,6 +406,60 @@ func _DatabaseService_GetRows_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DatabaseService_InsertRow_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InsertRowRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DatabaseServiceServer).InsertRow(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DatabaseService_InsertRow_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DatabaseServiceServer).InsertRow(ctx, req.(*InsertRowRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DatabaseService_UpdateRow_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateRowRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DatabaseServiceServer).UpdateRow(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DatabaseService_UpdateRow_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DatabaseServiceServer).UpdateRow(ctx, req.(*UpdateRowRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DatabaseService_DeleteRow_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteRowRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DatabaseServiceServer).DeleteRow(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DatabaseService_DeleteRow_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DatabaseServiceServer).DeleteRow(ctx, req.(*DeleteRowRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DatabaseService_ExecuteSQL_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ExecuteSQLRequest)
 	if err := dec(in); err != nil {
@@ -416,10 +518,22 @@ var DatabaseService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _DatabaseService_GetRows_Handler,
 		},
 		{
+			MethodName: "InsertRow",
+			Handler:    _DatabaseService_InsertRow_Handler,
+		},
+		{
+			MethodName: "UpdateRow",
+			Handler:    _DatabaseService_UpdateRow_Handler,
+		},
+		{
+			MethodName: "DeleteRow",
+			Handler:    _DatabaseService_DeleteRow_Handler,
+		},
+		{
 			MethodName: "ExecuteSQL",
 			Handler:    _DatabaseService_ExecuteSQL_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "proto/database/database.proto",
+	Metadata: "database/database.proto",
 }

--- a/proto/database/database.proto
+++ b/proto/database/database.proto
@@ -106,6 +106,39 @@ message GetRowsResponse {
   int64 total_count = 2;
 }
 
+// --- Row Mutations ---
+
+message InsertRowRequest {
+  string schema = 1;
+  string table = 2;
+  bytes values = 3;
+}
+
+message InsertRowResponse {
+  bytes row = 1;
+}
+
+message UpdateRowRequest {
+  string schema = 1;
+  string table = 2;
+  bytes pk = 3;
+  bytes values = 4;
+}
+
+message UpdateRowResponse {
+  bytes row = 1;
+}
+
+message DeleteRowRequest {
+  string schema = 1;
+  string table = 2;
+  bytes pk = 3;
+}
+
+message DeleteRowResponse {
+  int64 affected_rows = 1;
+}
+
 // --- SQL ---
 
 message ExecuteSQLRequest {
@@ -129,5 +162,8 @@ service DatabaseService {
   rpc UpdateColumn(UpdateColumnRequest) returns (UpdateColumnResponse);
   rpc DeleteColumn(DeleteColumnRequest) returns (DeleteColumnResponse);
   rpc GetRows(GetRowsRequest) returns (GetRowsResponse);
+  rpc InsertRow(InsertRowRequest) returns (InsertRowResponse);
+  rpc UpdateRow(UpdateRowRequest) returns (UpdateRowResponse);
+  rpc DeleteRow(DeleteRowRequest) returns (DeleteRowResponse);
   rpc ExecuteSQL(ExecuteSQLRequest) returns (ExecuteSQLResponse);
 }

--- a/services/database/repository/database_repo.go
+++ b/services/database/repository/database_repo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/KinuGra/giraffe-2604/services/database/model"
@@ -375,6 +376,200 @@ func (r *DatabaseRepo) ExecuteRawSQL(ctx context.Context, query string) ([][]byt
 
 	affected, _ := result.RowsAffected()
 	return nil, affected, nil
+}
+
+func parseJSONMap(data []byte) (map[string]interface{}, error) {
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if len(m) == 0 {
+		return nil, fmt.Errorf("empty JSON object")
+	}
+	return m, nil
+}
+
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func buildWhereClause(pk map[string]interface{}, startParam int) (string, []interface{}, error) {
+	keys := sortedKeys(pk)
+	conditions := make([]string, 0, len(keys))
+	args := make([]interface{}, 0, len(keys))
+	for i, k := range keys {
+		qk, err := QuoteIdent(k)
+		if err != nil {
+			return "", nil, err
+		}
+		conditions = append(conditions, fmt.Sprintf("%s = $%d", qk, startParam+i))
+		args = append(args, pk[k])
+	}
+	return strings.Join(conditions, " AND "), args, nil
+}
+
+func (r *DatabaseRepo) InsertRow(ctx context.Context, schema, table string, values []byte) ([]byte, error) {
+	quotedSchema, err := QuoteIdent(schema)
+	if err != nil {
+		return nil, err
+	}
+	quotedTable, err := QuoteIdent(table)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := parseJSONMap(values)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := sortedKeys(data)
+	quotedCols := make([]string, 0, len(keys))
+	placeholders := make([]string, 0, len(keys))
+	args := make([]interface{}, 0, len(keys))
+
+	for i, k := range keys {
+		qk, err := QuoteIdent(k)
+		if err != nil {
+			return nil, err
+		}
+		quotedCols = append(quotedCols, qk)
+		placeholders = append(placeholders, fmt.Sprintf("$%d", i+1))
+		args = append(args, data[k])
+	}
+
+	query := fmt.Sprintf("INSERT INTO %s.%s (%s) VALUES (%s) RETURNING *",
+		quotedSchema, quotedTable,
+		strings.Join(quotedCols, ", "),
+		strings.Join(placeholders, ", "))
+
+	sqlDB, err := r.db.DB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sql.DB: %w", err)
+	}
+
+	rows, err := sqlDB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("insert failed: %w", err)
+	}
+	defer rows.Close()
+
+	jsonRows, err := scanRowsToJSON(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(jsonRows) == 0 {
+		return nil, fmt.Errorf("insert returned no rows")
+	}
+	return jsonRows[0], nil
+}
+
+func (r *DatabaseRepo) UpdateRow(ctx context.Context, schema, table string, pk, values []byte) ([]byte, error) {
+	quotedSchema, err := QuoteIdent(schema)
+	if err != nil {
+		return nil, err
+	}
+	quotedTable, err := QuoteIdent(table)
+	if err != nil {
+		return nil, err
+	}
+
+	pkMap, err := parseJSONMap(pk)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pk: %w", err)
+	}
+	valMap, err := parseJSONMap(values)
+	if err != nil {
+		return nil, fmt.Errorf("invalid values: %w", err)
+	}
+
+	valKeys := sortedKeys(valMap)
+	setClauses := make([]string, 0, len(valKeys))
+	args := make([]interface{}, 0, len(valKeys)+len(pkMap))
+	paramIdx := 1
+
+	for _, k := range valKeys {
+		qk, err := QuoteIdent(k)
+		if err != nil {
+			return nil, err
+		}
+		setClauses = append(setClauses, fmt.Sprintf("%s = $%d", qk, paramIdx))
+		args = append(args, valMap[k])
+		paramIdx++
+	}
+
+	whereClause, whereArgs, err := buildWhereClause(pkMap, paramIdx)
+	if err != nil {
+		return nil, err
+	}
+	args = append(args, whereArgs...)
+
+	query := fmt.Sprintf("UPDATE %s.%s SET %s WHERE %s RETURNING *",
+		quotedSchema, quotedTable,
+		strings.Join(setClauses, ", "),
+		whereClause)
+
+	sqlDB, err := r.db.DB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sql.DB: %w", err)
+	}
+
+	rows, err := sqlDB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("update failed: %w", err)
+	}
+	defer rows.Close()
+
+	jsonRows, err := scanRowsToJSON(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(jsonRows) == 0 {
+		return nil, fmt.Errorf("row not found")
+	}
+	return jsonRows[0], nil
+}
+
+func (r *DatabaseRepo) DeleteRow(ctx context.Context, schema, table string, pk []byte) (int64, error) {
+	quotedSchema, err := QuoteIdent(schema)
+	if err != nil {
+		return 0, err
+	}
+	quotedTable, err := QuoteIdent(table)
+	if err != nil {
+		return 0, err
+	}
+
+	pkMap, err := parseJSONMap(pk)
+	if err != nil {
+		return 0, fmt.Errorf("invalid pk: %w", err)
+	}
+
+	whereClause, args, err := buildWhereClause(pkMap, 1)
+	if err != nil {
+		return 0, err
+	}
+
+	query := fmt.Sprintf("DELETE FROM %s.%s WHERE %s",
+		quotedSchema, quotedTable, whereClause)
+
+	sqlDB, err := r.db.DB()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get sql.DB: %w", err)
+	}
+
+	result, err := sqlDB.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("delete failed: %w", err)
+	}
+
+	affected, _ := result.RowsAffected()
+	return affected, nil
 }
 
 func scanRowsToJSON(rows interface {

--- a/services/database/server/server.go
+++ b/services/database/server/server.go
@@ -97,6 +97,30 @@ func (s *DatabaseServer) GetRows(ctx context.Context, req *pb.GetRowsRequest) (*
 	return &pb.GetRowsResponse{Rows: rows, TotalCount: totalCount}, nil
 }
 
+func (s *DatabaseServer) InsertRow(ctx context.Context, req *pb.InsertRowRequest) (*pb.InsertRowResponse, error) {
+	row, err := s.uc.InsertRow(ctx, req.Schema, req.Table, req.Values)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.InsertRowResponse{Row: row}, nil
+}
+
+func (s *DatabaseServer) UpdateRow(ctx context.Context, req *pb.UpdateRowRequest) (*pb.UpdateRowResponse, error) {
+	row, err := s.uc.UpdateRow(ctx, req.Schema, req.Table, req.Pk, req.Values)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.UpdateRowResponse{Row: row}, nil
+}
+
+func (s *DatabaseServer) DeleteRow(ctx context.Context, req *pb.DeleteRowRequest) (*pb.DeleteRowResponse, error) {
+	affected, err := s.uc.DeleteRow(ctx, req.Schema, req.Table, req.Pk)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.DeleteRowResponse{AffectedRows: affected}, nil
+}
+
 func (s *DatabaseServer) ExecuteSQL(ctx context.Context, req *pb.ExecuteSQLRequest) (*pb.ExecuteSQLResponse, error) {
 	rows, affected, elapsed, err := s.uc.ExecuteSQL(ctx, req.Query)
 	if err != nil {

--- a/services/database/usecase/database_usecase.go
+++ b/services/database/usecase/database_usecase.go
@@ -76,6 +76,18 @@ func (u *DatabaseUsecase) GetRows(ctx context.Context, schema, table string, lim
 	return u.repo.GetRows(ctx, defaultSchema(schema), table, limit, offset, orderBy)
 }
 
+func (u *DatabaseUsecase) InsertRow(ctx context.Context, schema, table string, values []byte) ([]byte, error) {
+	return u.repo.InsertRow(ctx, defaultSchema(schema), table, values)
+}
+
+func (u *DatabaseUsecase) UpdateRow(ctx context.Context, schema, table string, pk, values []byte) ([]byte, error) {
+	return u.repo.UpdateRow(ctx, defaultSchema(schema), table, pk, values)
+}
+
+func (u *DatabaseUsecase) DeleteRow(ctx context.Context, schema, table string, pk []byte) (int64, error) {
+	return u.repo.DeleteRow(ctx, defaultSchema(schema), table, pk)
+}
+
 func (u *DatabaseUsecase) ExecuteSQL(ctx context.Context, query string) ([][]byte, int64, float64, error) {
 	query = strings.TrimSpace(query)
 	start := time.Now()

--- a/services/gateway/routes/database.go
+++ b/services/gateway/routes/database.go
@@ -23,6 +23,9 @@ func RegisterDatabaseRoutes(r *gin.Engine, client pb.DatabaseServiceClient) {
 		g.DELETE("/tables/:name/columns/:column", deleteColumn(client))
 
 		g.GET("/tables/:name/rows", getRows(client))
+		g.POST("/tables/:name/rows", insertRow(client))
+		g.PUT("/tables/:name/rows", updateRow(client))
+		g.DELETE("/tables/:name/rows", deleteRow(client))
 		g.POST("/sql", executeSQL(client))
 	}
 }
@@ -284,6 +287,98 @@ func getRows(client pb.DatabaseServiceClient) gin.HandlerFunc {
 			"rows":       rows,
 			"totalCount": resp.TotalCount,
 		})
+	}
+}
+
+func insertRow(client pb.DatabaseServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		schema := c.DefaultQuery("schema", "public")
+		table := c.Param("name")
+
+		var body map[string]interface{}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		values, err := json.Marshal(body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON"})
+			return
+		}
+
+		resp, err := client.InsertRow(c.Request.Context(), &pb.InsertRowRequest{
+			Schema: schema,
+			Table:  table,
+			Values: values,
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.Data(http.StatusCreated, "application/json", resp.Row)
+	}
+}
+
+func updateRow(client pb.DatabaseServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		schema := c.DefaultQuery("schema", "public")
+		table := c.Param("name")
+
+		var body struct {
+			Pk     map[string]interface{} `json:"pk"`
+			Values map[string]interface{} `json:"values"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		pk, _ := json.Marshal(body.Pk)
+		values, _ := json.Marshal(body.Values)
+
+		resp, err := client.UpdateRow(c.Request.Context(), &pb.UpdateRowRequest{
+			Schema: schema,
+			Table:  table,
+			Pk:     pk,
+			Values: values,
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.Data(http.StatusOK, "application/json", resp.Row)
+	}
+}
+
+func deleteRow(client pb.DatabaseServiceClient) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		schema := c.DefaultQuery("schema", "public")
+		table := c.Param("name")
+
+		var body struct {
+			Pk map[string]interface{} `json:"pk"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		pk, _ := json.Marshal(body.Pk)
+
+		resp, err := client.DeleteRow(c.Request.Context(), &pb.DeleteRowRequest{
+			Schema: schema,
+			Table:  table,
+			Pk:     pk,
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"affectedRows": resp.AffectedRows})
 	}
 }
 


### PR DESCRIPTION
- Add database-api.ts API client and replace all mock data in editor components
- Add InsertRow/UpdateRow/DeleteRow gRPC RPCs to proto and regenerate
- Implement row mutations in repository (parameterized SQL), usecase, and server
- Add POST/PUT/DELETE /database/v1/tables/:name/rows gateway routes
- Create InsertRowDialog with dynamic form fields from column definitions
- Make RowInspector editable with Save (changed fields only) and Delete (2-step confirm)
- Implement working pagination, SQL execution tab, and schema switchins