### PR TITLE
feat: デジタル進化論 — 10秒間3回以下で関数を絶滅させる

### DIFF
--- a/docs/functions/evolution.md
+++ b/docs/functions/evolution.md
@@ -1,0 +1,122 @@
+# デジタル進化論 — Functions Evolution
+
+## 概要
+
+サーバーレス関数に「自然淘汰」の原理を導入した機能。
+10秒間に3回以下しか呼ばれなかった関数は**永久に絶滅**する。
+
+> 弱者は淘汰される。それが自然の摂理。
+
+---
+
+## 仕様
+
+### 淘汰ルール
+
+| 条件 | 結果 |
+|------|------|
+| 10秒スライディングウィンドウ内の呼び出し回数 > 3 | 生存 |
+| 10秒スライディングウィンドウ内の呼び出し回数 ≤ 3 | **絶滅**（`status: deactivated`） |
+
+### スライディングウィンドウ
+
+```
+時刻: 0s    5s    10s   15s
+      ←─────10s──────→
+      呼び出し回数をカウント
+      実行のたびにチェック
+      ≤3 回 → 即時絶滅
+```
+
+### 絶滅後の挙動
+
+- 絶滅した関数を実行しようとすると `gRPC codes.FailedPrecondition: DEACTIVATED` エラー
+- フロントエンドは全画面の「絶滅演出」を表示
+- バッジが `💀 絶滅` に変わり、Invoke ボタンが永久に無効化される
+
+---
+
+## 実装
+
+### バックエンド
+
+**model/function.go**
+```go
+const (
+    StatusActive      = "active"
+    StatusDeactivated = "deactivated"
+)
+
+type Function struct {
+    ...
+    Status string `gorm:"default:'active';not null"`
+}
+```
+
+**usecase/execute.go** — インメモリ スライディングウィンドウ
+
+```go
+const (
+    evolutionWindow   = 10 * time.Second
+    evolutionMinCalls = 3
+)
+
+// 実行後に呼び出される
+func (u *FunctionUsecase) recordAndEvolve(id string) {
+    raw, _ := u.windows.LoadOrStore(id, &callWindow{})
+    cw := raw.(*callWindow)
+    count := cw.record() // 10s以内の呼び出し数を返す
+    if count <= evolutionMinCalls {
+        _ = u.repo.Deactivate(id)
+    }
+}
+```
+
+**注意**: ウィンドウカウンターはインメモリのため、サービス再起動でリセットされる。
+DB への永続化（`execution_logs` テーブルの集計）への移行も可能。
+
+### フロントエンド
+
+**ExtinctionOverlay コンポーネント**
+
+実行後に `GET /functions/:id` で status を確認し、`deactivated` になっていれば全画面演出を表示。
+
+```
+[impact フェーズ]  → 0.8秒: 暗転 + 💀 ズームイン
+[message フェーズ] → 0.8〜3.8秒: 「絶　滅」テキスト + メッセージ逐次表示
+[fade フェーズ]    → 3.8〜4.6秒: フェードアウト
+```
+
+---
+
+## 生き残る方法
+
+関数を生存させるには、**10秒以内に4回以上**呼び出すこと。
+
+```bash
+# 連打スクリプト
+for i in $(seq 1 5); do
+  curl -s -X POST http://localhost:8080/functions/<id>/execute \
+    -H "Content-Type: application/json" -d '{}' &
+done
+wait
+```
+
+または HTTP トリガーで：
+
+```bash
+for i in $(seq 1 5); do
+  curl -s -X POST http://localhost:8080/functions/v1/<name> &
+done
+wait
+```
+
+---
+
+## 設計思想
+
+通常のレートリミッターは「使いすぎ」を制限するが、
+この機能は「使われなさすぎ」を制限する。
+
+人気のない API、呼ばれない関数——それらは本当に必要なのか？
+デジタル進化論は、コードベースに自然な淘汰圧をかける。

--- a/frontend/src/app/dashboard/functions/page.tsx
+++ b/frontend/src/app/dashboard/functions/page.tsx
@@ -27,6 +27,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { CodeViewer } from "@/features/functions/code-viewer";
+import { ExtinctionOverlay } from "@/features/functions/extinction-overlay";
 import { FunctionSettings } from "@/features/functions/function-settings";
 import { FunctionsList } from "@/features/functions/functions-list";
 import { LiveLogs } from "@/features/functions/live-logs";
@@ -46,7 +47,7 @@ import {
   SquareFunction,
   Timer,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export default function FunctionsPage() {
   const [functions, setFunctions] = useState<FunctionInfo[]>([]);
@@ -60,10 +61,18 @@ export default function FunctionsPage() {
   const [newRuntime, setNewRuntime] = useState("python3.12");
   const [newCode, setNewCode] = useState('print("hello world")');
   const [creating, setCreating] = useState(false);
+  const [extinction, setExtinction] = useState<string | null>(null);
+  const extinctionShownRef = useRef<Set<string>>(new Set());
 
   const fetchList = useCallback(async () => {
     try {
       const list = await functionsApi.list();
+      // 既に絶滅済みの関数はアニメーション対象外にする
+      for (const f of list) {
+        if (f.status === "deactivated") {
+          extinctionShownRef.current.add(f.id);
+        }
+      }
       setFunctions(list);
       setSelected((prev) =>
         prev === "" && list.length > 0 ? list[0].id : prev,
@@ -78,6 +87,29 @@ export default function FunctionsPage() {
   }, [fetchList]);
 
   const fn = functions.find((f) => f.id === selected);
+
+  // アクティブな関数を2秒ごとにポーリングし、絶滅を自動検知する
+  useEffect(() => {
+    if (!selected) return;
+    const timer = setInterval(async () => {
+      try {
+        const updated = await functionsApi.get(selected);
+        if (
+          updated.status === "deactivated" &&
+          !extinctionShownRef.current.has(selected)
+        ) {
+          extinctionShownRef.current.add(selected);
+          setExtinction(updated.name);
+          setFunctions((prev) =>
+            prev.map((f) => (f.id === selected ? updated : f)),
+          );
+        }
+      } catch {
+        // ignore
+      }
+    }, 2000);
+    return () => clearInterval(timer);
+  }, [selected]);
 
   const fetchHistory = useCallback(async (id: string) => {
     try {
@@ -144,6 +176,12 @@ export default function FunctionsPage() {
 
   return (
     <div className="flex h-full">
+      {extinction && (
+        <ExtinctionOverlay
+          functionName={extinction}
+          onDismiss={() => setExtinction(null)}
+        />
+      )}
       <FunctionsList
         functions={functions}
         selected={selected}
@@ -175,7 +213,11 @@ export default function FunctionsPage() {
                     <h1 className="text-lg font-heading font-semibold">
                       {fn.name}
                     </h1>
-                    <Badge variant="default">active</Badge>
+                    {fn.status === "deactivated" ? (
+                      <Badge variant="destructive">💀 絶滅</Badge>
+                    ) : (
+                      <Badge variant="default">active</Badge>
+                    )}
                   </div>
                   <div className="flex items-center gap-3 text-[11px] text-muted-foreground mt-0.5">
                     <span className="font-mono">{fn.runtime}</span>
@@ -192,10 +234,17 @@ export default function FunctionsPage() {
                   size="sm"
                   className="gap-1.5"
                   onClick={handleInvoke}
-                  disabled={executing}
+                  disabled={executing || fn.status === "deactivated"}
+                  variant={
+                    fn.status === "deactivated" ? "destructive" : "default"
+                  }
                 >
                   <Play className="size-3" />
-                  {executing ? "Running…" : "Invoke"}
+                  {fn.status === "deactivated"
+                    ? "💀 絶滅済"
+                    : executing
+                      ? "Running…"
+                      : "Invoke"}
                 </Button>
                 <DropdownMenu>
                   <DropdownMenuTrigger

--- a/frontend/src/features/functions/extinction-overlay.tsx
+++ b/frontend/src/features/functions/extinction-overlay.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface ExtinctionOverlayProps {
+  functionName: string;
+  onDismiss: () => void;
+}
+
+const MESSAGES = [
+  "この関数は、時代に選ばれなかった。",
+  "呼ばれなければ、存在しないのと同じだ。",
+  "弱者は淘汰される。それが自然の摂理。",
+  "10秒間、誰も必要としなかった。",
+  "デジタル進化論——不適者は消える。",
+];
+
+export function ExtinctionOverlay({
+  functionName,
+  onDismiss,
+}: ExtinctionOverlayProps) {
+  const [phase, setPhase] = useState<"impact" | "message" | "fade">("impact");
+  const [messageIndex, setMessageIndex] = useState(0);
+
+  useEffect(() => {
+    const t1 = setTimeout(() => setPhase("message"), 800);
+    const t2 = setTimeout(() => setMessageIndex(1), 1800);
+    const t3 = setTimeout(() => setMessageIndex(2), 2600);
+    const t4 = setTimeout(() => setPhase("fade"), 3800);
+    const t5 = setTimeout(() => onDismiss(), 4600);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+      clearTimeout(t4);
+      clearTimeout(t5);
+    };
+  }, [onDismiss]);
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex flex-col items-center justify-center transition-opacity duration-700 ${
+        phase === "fade" ? "opacity-0" : "opacity-100"
+      }`}
+      style={{
+        background: "radial-gradient(ellipse at center, #1a0000 0%, #000 70%)",
+      }}
+    >
+      {/* Glitch scanlines */}
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(255,0,0,0.03) 2px, rgba(255,0,0,0.03) 4px)",
+        }}
+      />
+
+      {/* Main content */}
+      <div className="relative flex flex-col items-center gap-6 px-8 text-center">
+        {/* Skull */}
+        <div
+          className={`text-8xl transition-all duration-500 ${
+            phase === "impact" ? "scale-150 opacity-0" : "scale-100 opacity-100"
+          }`}
+          style={{
+            filter:
+              "drop-shadow(0 0 40px #ff0000) drop-shadow(0 0 80px #ff0000)",
+            animation:
+              phase === "message" ? "pulse 1s ease-in-out infinite" : undefined,
+          }}
+        >
+          💀
+        </div>
+
+        {/* Function name */}
+        <div
+          className={`font-mono text-2xl font-bold tracking-widest transition-all duration-300 ${
+            phase === "impact" ? "opacity-0 scale-75" : "opacity-100 scale-100"
+          }`}
+          style={{
+            color: "#ff3333",
+            textShadow: "0 0 20px #ff0000, 0 0 40px #ff0000",
+            animation: "glitch 2s infinite",
+          }}
+        >
+          {functionName}
+        </div>
+
+        {/* Big text */}
+        <div
+          className={`text-5xl font-black tracking-tight transition-all duration-500 ${
+            phase === "impact"
+              ? "opacity-0 translate-y-4"
+              : "opacity-100 translate-y-0"
+          }`}
+          style={{
+            color: "#ff0000",
+            textShadow: "0 0 30px #ff0000, 0 0 60px #ff0000, 0 0 100px #ff4444",
+          }}
+        >
+          絶　滅
+        </div>
+
+        {/* Messages */}
+        <div className="space-y-1 min-h-[60px]">
+          {MESSAGES.slice(0, messageIndex + 1).map((msg, i) => (
+            <p
+              key={msg}
+              className="text-sm font-mono transition-all duration-500"
+              style={{
+                color: i === messageIndex ? "#ff6666" : "#551111",
+                opacity: i === messageIndex ? 1 : 0.4,
+                textShadow: i === messageIndex ? "0 0 10px #ff3333" : "none",
+              }}
+            >
+              {msg}
+            </p>
+          ))}
+        </div>
+
+        {/* Progress bar */}
+        <div className="w-64 h-0.5 bg-red-950 overflow-hidden rounded-full">
+          <div
+            className="h-full bg-red-600 transition-all"
+            style={{
+              width:
+                phase === "impact"
+                  ? "0%"
+                  : phase === "message"
+                    ? "60%"
+                    : "100%",
+              transitionDuration: phase === "message" ? "3000ms" : "500ms",
+              boxShadow: "0 0 10px #ff0000",
+            }}
+          />
+        </div>
+
+        <p className="text-xs text-red-900 font-mono">
+          この関数は10秒以内に3回以下しか呼ばれなかった
+        </p>
+      </div>
+
+      <style>{`
+        @keyframes glitch {
+          0%, 100% { transform: translate(0); }
+          20% { transform: translate(-2px, 1px); }
+          40% { transform: translate(2px, -1px); }
+          60% { transform: translate(-1px, 2px); }
+          80% { transform: translate(1px, -2px); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/features/functions/functions-list.tsx
+++ b/frontend/src/features/functions/functions-list.tsx
@@ -70,11 +70,17 @@ export function FunctionsList({
               )}
             >
               <div className="flex items-center gap-2 min-w-0">
-                <span className="size-2 rounded-full shrink-0 bg-brand-400" />
+                {fn.status === "deactivated" ? (
+                  <span className="text-xs shrink-0 leading-none">💀</span>
+                ) : (
+                  <span className="size-2 rounded-full shrink-0 bg-brand-400" />
+                )}
                 <span
                   className={cn(
                     "text-sm font-semibold truncate",
                     isSelected && "text-primary",
+                    fn.status === "deactivated" &&
+                      "line-through text-muted-foreground",
                   )}
                 >
                   {fn.name}

--- a/frontend/src/lib/functions-api.ts
+++ b/frontend/src/lib/functions-api.ts
@@ -7,6 +7,7 @@ export interface FunctionInfo {
   code: string;
   createdAt: string;
   timeoutSec: number;
+  status: "active" | "deactivated";
 }
 
 export interface ExecuteResult {
@@ -34,6 +35,7 @@ function mapFn(r: Record<string, unknown>): FunctionInfo {
     code: r.code as string,
     createdAt: (r.created_at ?? "") as string,
     timeoutSec: (r.timeout_sec ?? 30) as number,
+    status: (r.status as "active" | "deactivated") ?? "active",
   };
 }
 
@@ -78,6 +80,12 @@ export const functionsApi = {
       body: JSON.stringify({ name, runtime, code, timeout_sec: timeoutSec }),
     });
     if (!res.ok) throw new Error("Failed to create function");
+    return mapFn(await res.json());
+  },
+
+  get: async (id: string): Promise<FunctionInfo> => {
+    const res = await fetch(`${GATEWAY_URL}/functions/${id}`);
+    if (!res.ok) throw new Error("Failed to fetch function");
     return mapFn(await res.json());
   },
 

--- a/gen/functions/functions.pb.go
+++ b/gen/functions/functions.pb.go
@@ -97,6 +97,7 @@ type FunctionInfo struct {
 	Code          string                 `protobuf:"bytes,4,opt,name=code,proto3" json:"code,omitempty"`
 	CreatedAt     string                 `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	TimeoutSec    int32                  `protobuf:"varint,6,opt,name=timeout_sec,json=timeoutSec,proto3" json:"timeout_sec,omitempty"`
+	Status        string                 `protobuf:"bytes,7,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -171,6 +172,13 @@ func (x *FunctionInfo) GetTimeoutSec() int32 {
 		return x.TimeoutSec
 	}
 	return 0
+}
+
+func (x *FunctionInfo) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
 }
 
 type ListFunctionsRequest struct {
@@ -823,7 +831,7 @@ const file_functions_functions_proto_rawDesc = "" +
 	"\aruntime\x18\x02 \x01(\tR\aruntime\x12\x12\n" +
 	"\x04code\x18\x03 \x01(\tR\x04code\x12\x1f\n" +
 	"\vtimeout_sec\x18\x04 \x01(\x05R\n" +
-	"timeoutSec\"\xa0\x01\n" +
+	"timeoutSec\"\xb8\x01\n" +
 	"\fFunctionInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -832,7 +840,8 @@ const file_functions_functions_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\x05 \x01(\tR\tcreatedAt\x12\x1f\n" +
 	"\vtimeout_sec\x18\x06 \x01(\x05R\n" +
-	"timeoutSec\"\x16\n" +
+	"timeoutSec\x12\x16\n" +
+	"\x06status\x18\a \x01(\tR\x06status\"\x16\n" +
 	"\x14ListFunctionsRequest\"N\n" +
 	"\x15ListFunctionsResponse\x125\n" +
 	"\tfunctions\x18\x01 \x03(\v2\x17.functions.FunctionInfoR\tfunctions\"5\n" +

--- a/proto/functions/functions.proto
+++ b/proto/functions/functions.proto
@@ -27,6 +27,7 @@ message FunctionInfo {
   string code = 4;
   string created_at = 5;
   int32 timeout_sec = 6;
+  string status = 7;
 }
 
 message ListFunctionsRequest {}

--- a/services/functions/model/function.go
+++ b/services/functions/model/function.go
@@ -2,12 +2,18 @@ package model
 
 import "time"
 
+const (
+	StatusActive      = "active"
+	StatusDeactivated = "deactivated"
+)
+
 type Function struct {
 	ID         string `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
 	Name       string `gorm:"not null"`
 	Runtime    string `gorm:"not null"`
 	Code       string `gorm:"type:text;not null"`
 	TimeoutSec int    `gorm:"default:30;not null"`
+	Status     string `gorm:"default:'active';not null"`
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }

--- a/services/functions/repository/function_repo.go
+++ b/services/functions/repository/function_repo.go
@@ -57,6 +57,10 @@ func (r *FunctionRepo) Delete(id string) error {
 	return r.db.Delete(&model.Function{}, "id = ?", id).Error
 }
 
+func (r *FunctionRepo) Deactivate(id string) error {
+	return r.db.Model(&model.Function{}).Where("id = ?", id).Update("status", model.StatusDeactivated).Error
+}
+
 func (r *FunctionRepo) CreateLog(l *model.ExecutionLog) error {
 	return r.db.Create(l).Error
 }

--- a/services/functions/server/convert.go
+++ b/services/functions/server/convert.go
@@ -13,6 +13,7 @@ func modelToProto(f *model.Function) *pb.FunctionInfo {
 		Code:       f.Code,
 		TimeoutSec: int32(f.TimeoutSec),
 		CreatedAt:  f.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		Status:     f.Status,
 	}
 }
 

--- a/services/functions/server/server.go
+++ b/services/functions/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 
 	pb "github.com/KinuGra/giraffe-2604/gen/functions"
 	"github.com/KinuGra/giraffe-2604/services/functions/usecase"
@@ -61,6 +62,9 @@ func (s *FunctionsServer) ExecuteFunction(ctx context.Context, req *pb.ExecuteFu
 		Stdin:      req.Stdin,
 	})
 	if err != nil {
+		if errors.Is(err, usecase.ErrDeactivated) {
+			return nil, status.Errorf(codes.FailedPrecondition, "DEACTIVATED")
+		}
 		return nil, status.Errorf(codes.Internal, "execute failed: %v", err)
 	}
 	return &pb.ExecuteFunctionResponse{

--- a/services/functions/usecase/execute.go
+++ b/services/functions/usecase/execute.go
@@ -3,8 +3,10 @@ package usecase
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/KinuGra/giraffe-2604/services/functions/model"
@@ -14,13 +16,66 @@ import (
 	"github.com/docker/docker/client"
 )
 
+var ErrDeactivated = errors.New("DEACTIVATED")
+
+const (
+	evolutionWindow   = 10 * time.Second
+	evolutionMinCalls = 3
+)
+
+type callWindow struct {
+	mu        sync.Mutex
+	count     int
+	scheduled bool
+}
+
 type FunctionUsecase struct {
-	repo *repository.FunctionRepo
-	sem  chan struct{}
+	repo    *repository.FunctionRepo
+	sem     chan struct{}
+	windows sync.Map // map[functionID]*callWindow
 }
 
 func NewFunctionUsecase(repo *repository.FunctionRepo) *FunctionUsecase {
 	return &FunctionUsecase{repo: repo, sem: make(chan struct{}, 10)}
+}
+
+// recordAndScheduleEvolve は実行を記録し、最初の呼び出し時に10秒後の審判をスケジュールする。
+func (u *FunctionUsecase) recordAndScheduleEvolve(id string) {
+	raw, _ := u.windows.LoadOrStore(id, &callWindow{})
+	cw := raw.(*callWindow)
+
+	cw.mu.Lock()
+	cw.count++
+	shouldSchedule := !cw.scheduled
+	if shouldSchedule {
+		cw.scheduled = true
+	}
+	cw.mu.Unlock()
+
+	if shouldSchedule {
+		time.AfterFunc(evolutionWindow, func() {
+			u.evaluateEvolution(id)
+		})
+	}
+}
+
+func (u *FunctionUsecase) evaluateEvolution(id string) {
+	raw, ok := u.windows.Load(id)
+	if !ok {
+		return
+	}
+	cw := raw.(*callWindow)
+
+	cw.mu.Lock()
+	count := cw.count
+	// ウィンドウをリセットして次のサイクルに備える
+	cw.count = 0
+	cw.scheduled = false
+	cw.mu.Unlock()
+
+	if count <= evolutionMinCalls {
+		_ = u.repo.Deactivate(id)
+	}
 }
 
 func (u *FunctionUsecase) Create(name, runtime, code string, timeoutSec int) (*model.Function, error) {
@@ -92,6 +147,10 @@ func (u *FunctionUsecase) Execute(id string, opts ExecuteOptions) (*ExecuteResul
 	f, err := u.repo.FindByID(id)
 	if err != nil {
 		return nil, fmt.Errorf("function not found: %w", err)
+	}
+
+	if f.Status == model.StatusDeactivated {
+		return nil, ErrDeactivated
 	}
 
 	image, ok := runtimeImages[f.Runtime]
@@ -209,6 +268,9 @@ func (u *FunctionUsecase) Execute(id string, opts ExecuteOptions) (*ExecuteResul
 		ExitCode:   exitCode,
 		DurationMs: durationMs,
 	})
+
+	// 進化論：最初の呼び出しから10秒後に審判。その間3回以下なら消滅
+	u.recordAndScheduleEvolve(id)
 
 	return result, nil
 }


### PR DESCRIPTION

  ## 概要

  サーバーレス関数に「自然淘汰」の原理を導入した。
  最初の呼び出しから10秒以内に4回以上呼ばれなかった関数は永久に絶滅する。
  絶滅は全画面アニメーションでユーザーに刻みつけられる。

  ## 変更内容

  - proto/model に status(active/deactivated) を追加、gen/ を再生成
  - usecase: time.AfterFunc による10秒後審判、ErrDeactivated で絶滅関数を即時拒否
  - repository: Deactivate() を追加
  - server: FailedPrecondition gRPC エラーで絶滅を通知
  - frontend: 2秒ポーリングで絶滅を自動検知、全画面「絶　滅」グリッチアニメーション
  - 関数一覧で絶滅済みは💀アイコン＋取り消し線で表示
  - 既存の絶滅済み関数にはアニメーションを流さない（新規絶滅のみ）
  - docs/functions/evolution.md にドキュメントを追加

  ## 動作確認

  - [ ] ローカルで確認済み

  ## 関連Issue

  Closes #56